### PR TITLE
PHPUnit to Pest Converter

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -33,4 +33,4 @@ jobs:
               run: composer update --${{ matrix.dependency-version }} --ignore-platform-req=php --no-interaction --no-progress
 
             - name: Execute tests
-              run: vendor/bin/phpunit
+              run: vendor/bin/pest

--- a/composer.json
+++ b/composer.json
@@ -23,10 +23,10 @@
         "phpstan/extension-installer": "^1.1",
         "phpstan/phpstan-deprecation-rules": "^1.0",
         "phpstan/phpstan-phpunit": "^1.0",
-        "phpunit/phpunit": "^9.5",
         "spatie/ignition": "dev-main",
         "spatie/laravel-ignition": "dev-main",
-        "spatie/phpunit-snapshot-assertions": "^4.0"
+        "spatie/phpunit-snapshot-assertions": "^4.0",
+        "pestphp/pest": "^1.20"
     },
     "autoload": {
         "psr-4": {
@@ -46,7 +46,6 @@
         "format": "vendor/bin/php-cs-fixer fix --allow-risky=yes",
         "test": "vendor/bin/phpunit",
         "test-coverage": "vendor/bin/phpunit --coverage-html coverage"
-
     },
     "config": {
         "sort-packages": true

--- a/composer.json
+++ b/composer.json
@@ -44,7 +44,7 @@
     "scripts": {
         "analyse": "vendor/bin/phpstan analyse",
         "format": "vendor/bin/php-cs-fixer fix --allow-risky=yes",
-        "test": "vendor/bin/phpunit",
+        "test": "vendor/bin/pest",
         "test-coverage": "vendor/bin/phpunit --coverage-html coverage"
     },
     "config": {

--- a/tests/Context/ConsoleContextTest.php
+++ b/tests/Context/ConsoleContextTest.php
@@ -14,5 +14,5 @@ it('can return the context as an array', function () {
 
     $context = new ConsoleContextProvider($arguments);
 
-    $this->assertEquals(['arguments' => $arguments], $context->toArray());
+    expect($context->toArray())->toEqual(['arguments' => $arguments]);
 });

--- a/tests/Context/ConsoleContextTest.php
+++ b/tests/Context/ConsoleContextTest.php
@@ -3,7 +3,6 @@
 use Spatie\FlareClient\Context\ConsoleContextProvider;
 use Spatie\FlareClient\Tests\TestCase;
 
-uses(TestCase::class);
 
 it('can return the context as an array', function () {
     $arguments = [

--- a/tests/Context/ConsoleContextTest.php
+++ b/tests/Context/ConsoleContextTest.php
@@ -1,23 +1,18 @@
 <?php
 
-namespace Spatie\FlareClient\Tests\Context;
-
 use Spatie\FlareClient\Context\ConsoleContextProvider;
 use Spatie\FlareClient\Tests\TestCase;
 
-class ConsoleContextTest extends TestCase
-{
-    /** @test */
-    public function it_can_return_the_context_as_an_array()
-    {
-        $arguments = [
-            'argument 1',
-            'argument 2',
-            'argument 3',
-        ];
+uses(TestCase::class);
 
-        $context = new ConsoleContextProvider($arguments);
+it('can return the context as an array', function () {
+    $arguments = [
+        'argument 1',
+        'argument 2',
+        'argument 3',
+    ];
 
-        $this->assertEquals(['arguments' => $arguments], $context->toArray());
-    }
-}
+    $context = new ConsoleContextProvider($arguments);
+
+    $this->assertEquals(['arguments' => $arguments], $context->toArray());
+});

--- a/tests/Context/ConsoleContextTest.php
+++ b/tests/Context/ConsoleContextTest.php
@@ -1,8 +1,6 @@
 <?php
 
 use Spatie\FlareClient\Context\ConsoleContextProvider;
-use Spatie\FlareClient\Tests\TestCase;
-
 
 it('can return the context as an array', function () {
     $arguments = [

--- a/tests/Context/RequestContextTest.php
+++ b/tests/Context/RequestContextTest.php
@@ -6,7 +6,6 @@ use Spatie\FlareClient\Tests\TestCase;
 use Symfony\Component\HttpFoundation\File\UploadedFile;
 use Symfony\Component\HttpFoundation\Request;
 
-uses(TestCase::class);
 uses(MatchesCodeSnippetSnapshots::class);
 
 it('can return the context as an array', function () {

--- a/tests/Context/RequestContextTest.php
+++ b/tests/Context/RequestContextTest.php
@@ -1,58 +1,52 @@
 <?php
 
-namespace Spatie\FlareClient\Tests\Context;
-
 use Spatie\FlareClient\Context\RequestContextProvider;
 use Spatie\FlareClient\Tests\Concerns\MatchesCodeSnippetSnapshots;
 use Spatie\FlareClient\Tests\TestCase;
 use Symfony\Component\HttpFoundation\File\UploadedFile;
 use Symfony\Component\HttpFoundation\Request;
 
-class RequestContextTest extends TestCase
-{
-    use MatchesCodeSnippetSnapshots;
+uses(TestCase::class);
+uses(MatchesCodeSnippetSnapshots::class);
 
-    /** @test */
-    public function it_can_return_the_context_as_an_array()
-    {
-        $get = ['get-key-1' => 'get-value-1'];
+it('can return the context as an array', function () {
+    $get = ['get-key-1' => 'get-value-1'];
 
-        $post = ['post-key-1' => 'post-value-1'];
+    $post = ['post-key-1' => 'post-value-1'];
 
-        $request = [];
+    $request = [];
 
-        $cookies = ['cookie-key-1' => 'cookie-value-1'];
+    $cookies = ['cookie-key-1' => 'cookie-value-1'];
 
-        $files = [
-            'file-one' => new UploadedFile(
-                $this->getStubPath('file.txt'),
-                'file-name.txt',
-                'text/plain',
-                UPLOAD_ERR_OK
-            ),
-            'file-two' => new UploadedFile(
-                $this->getStubPath('file.txt'),
-                'file-name.txt',
-                'text/plain',
-                UPLOAD_ERR_OK
-            ),
-        ];
+    $files = [
+        'file-one' => new UploadedFile(
+            $this->getStubPath('file.txt'),
+            'file-name.txt',
+            'text/plain',
+            UPLOAD_ERR_OK
+        ),
+        'file-two' => new UploadedFile(
+            $this->getStubPath('file.txt'),
+            'file-name.txt',
+            'text/plain',
+            UPLOAD_ERR_OK
+        ),
+    ];
 
-        $server = [
-            'HTTP_HOST' => 'example.com',
-            'REMOTE_ADDR' => '1.2.3.4',
-            'SERVER_PORT' => '80',
-            'REQUEST_URI' => '/test',
-        ];
+    $server = [
+        'HTTP_HOST' => 'example.com',
+        'REMOTE_ADDR' => '1.2.3.4',
+        'SERVER_PORT' => '80',
+        'REQUEST_URI' => '/test',
+    ];
 
-        $content = 'my content';
+    $content = 'my content';
 
-        $request = new Request($get, $post, $request, $cookies, $files, $server, $content);
+    $request = new Request($get, $post, $request, $cookies, $files, $server, $content);
 
-        $context = new RequestContextProvider($request);
+    $context = new RequestContextProvider($request);
 
-        $contextArray = $context->toArray();
+    $contextArray = $context->toArray();
 
-        $this->assertMatchesCodeSnippetSnapshot($contextArray);
-    }
-}
+    $this->assertMatchesCodeSnippetSnapshot($contextArray);
+});

--- a/tests/Context/RequestContextTest.php
+++ b/tests/Context/RequestContextTest.php
@@ -2,7 +2,6 @@
 
 use Spatie\FlareClient\Context\RequestContextProvider;
 use Spatie\FlareClient\Tests\Concerns\MatchesCodeSnippetSnapshots;
-use Spatie\FlareClient\Tests\TestCase;
 use Symfony\Component\HttpFoundation\File\UploadedFile;
 use Symfony\Component\HttpFoundation\Request;
 

--- a/tests/FlareTest.php
+++ b/tests/FlareTest.php
@@ -7,7 +7,6 @@ use Spatie\FlareClient\Tests\Concerns\MatchesReportSnapshots;
 use Spatie\FlareClient\Tests\Mocks\FakeClient;
 use Spatie\FlareClient\Tests\TestClasses\ExceptionWithContext;
 
-uses(TestCase::class);
 uses(MatchesReportSnapshots::class);
 
 beforeEach(function () {

--- a/tests/FlareTest.php
+++ b/tests/FlareTest.php
@@ -126,9 +126,9 @@ it('can return groups', function () {
 
     $this->flare->group('custom group', ['my key' => 'my value']);
 
-    $this->assertSame(['key' => 'value'], $this->flare->getGroup());
-    $this->assertSame([], $this->flare->getGroup('foo'));
-    $this->assertSame(['my key' => 'my value'], $this->flare->getGroup('custom group'));
+    expect($this->flare->getGroup())->toBe(['key' => 'value']);
+    expect($this->flare->getGroup('foo'))->toBe([]);
+    expect($this->flare->getGroup('custom group'))->toBe(['my key' => 'my value']);
 });
 
 it('can merge groups', function () {
@@ -200,13 +200,13 @@ it('can add glows', function () {
 });
 
 test('a version callable can be set', function () {
-    $this->assertNull($this->flare->version());
+    expect($this->flare->version())->toBeNull();
 
     $this->flare->determineVersionUsing(function () {
         return '123';
     });
 
-    $this->assertEquals('123', $this->flare->version());
+    expect($this->flare->version())->toEqual('123');
 });
 
 it('will add the version to the report', function () {
@@ -214,7 +214,7 @@ it('will add the version to the report', function () {
 
     $payload = $this->fakeClient->getLastPayload();
 
-    $this->assertNull($payload['application_version']);
+    expect($payload['application_version'])->toBeNull();
 
     $this->flare->determineVersionUsing(function () {
         return '123';
@@ -224,7 +224,7 @@ it('will add the version to the report', function () {
 
     $payload = $this->fakeClient->getLastPayload();
 
-    $this->assertEquals('123', $payload['application_version']);
+    expect($payload['application_version'])->toEqual('123');
 });
 
 it('can filter exceptions being reported', function () {

--- a/tests/FlareTest.php
+++ b/tests/FlareTest.php
@@ -1,14 +1,11 @@
 <?php
 
-use Error;
-use ErrorException;
 use PHPUnit\Framework\Exception;
 use Spatie\FlareClient\Enums\MessageLevels;
 use Spatie\FlareClient\Flare;
 use Spatie\FlareClient\Tests\Concerns\MatchesReportSnapshots;
 use Spatie\FlareClient\Tests\Mocks\FakeClient;
 use Spatie\FlareClient\Tests\TestClasses\ExceptionWithContext;
-use Throwable;
 
 uses(TestCase::class);
 uses(MatchesReportSnapshots::class);

--- a/tests/FlareTest.php
+++ b/tests/FlareTest.php
@@ -1,7 +1,5 @@
 <?php
 
-namespace Spatie\FlareClient\Tests;
-
 use Error;
 use ErrorException;
 use PHPUnit\Framework\Exception;
@@ -12,336 +10,287 @@ use Spatie\FlareClient\Tests\Mocks\FakeClient;
 use Spatie\FlareClient\Tests\TestClasses\ExceptionWithContext;
 use Throwable;
 
-class FlareTest extends TestCase
+uses(TestCase::class);
+uses(MatchesReportSnapshots::class);
+
+beforeEach(function () {
+    $this->fakeClient = new FakeClient();
+
+    $this->flare = new Flare($this->fakeClient);
+
+    $this->useTime('2019-01-01 12:34:56');
+});
+
+it('can report an exception', function () {
+    reportException();
+
+    $this->fakeClient->assertRequestsSent(1);
+
+    $report = $this->fakeClient->getLastPayload();
+
+    $this->assertMatchesReportSnapshot($report);
+});
+
+it('can reset queued exceptions', function () {
+    reportException();
+
+    $this->flare->reset();
+
+    $this->fakeClient->assertRequestsSent(1);
+
+    $this->flare->reset();
+
+    $this->fakeClient->assertRequestsSent(1);
+});
+
+it('can add user provided context', function () {
+    $this->flare->context('my key', 'my value');
+
+    reportException();
+
+    $this->fakeClient->assertLastRequestHas('context.context', [
+        'my key' => 'my value',
+    ]);
+});
+
+test('callbacks can modify the report', function () {
+    $this->flare->context('my key', 'my value');
+    $this->flare->stage('production');
+    $this->flare->messageLevel('info');
+
+    $throwable = new Exception('This is a test');
+
+    $this->flare->report($throwable, function ($report) {
+        $report->context('my key', 'new value');
+        $report->stage('development');
+        $report->messageLevel('warning');
+    });
+
+    $this->fakeClient->assertLastRequestHas('context.context', [
+        'my key' => 'new value',
+    ]);
+    $this->fakeClient->assertLastRequestHas('stage', 'development');
+    $this->fakeClient->assertLastRequestHas('message_level', 'warning');
+});
+
+it('can censor request data', function () {
+    $_ENV['FLARE_FAKE_WEB_REQUEST'] = true;
+    $_POST['user'] = 'john@example.com';
+    $_POST['password'] = 'secret';
+
+    $this->flare->censorRequestBodyFields(['user', 'password']);
+
+    reportException();
+
+    $this->fakeClient->assertLastRequestContains('context.request_data.body', [
+        'user' => '<CENSORED>',
+        'password' => '<CENSORED>',
+    ]);
+});
+
+it('can merge user provided context', function () {
+    $this->flare->context('my key', 'my value');
+
+    $this->flare->context('another key', 'another value');
+
+    reportException();
+
+    $this->fakeClient->assertLastRequestHas('context.context', [
+        'my key' => 'my value',
+        'another key' => 'another value',
+    ]);
+});
+
+it('can add custom exception context', function () {
+    $this->flare->context('my key', 'my value');
+
+    $throwable = new ExceptionWithContext('This is a test');
+
+    $this->flare->report($throwable);
+
+    $this->fakeClient->assertLastRequestHas('context.context', [
+        'my key' => 'my value',
+        'another key' => 'another value',
+    ]);
+});
+
+it('can add a group', function () {
+    $this->flare->group('custom group', ['my key' => 'my value']);
+
+    reportException();
+
+    $this->fakeClient->assertLastRequestHas('context.custom group', [
+        'my key' => 'my value',
+    ]);
+});
+
+it('can return groups', function () {
+    $this->flare->context('key', 'value');
+
+    $this->flare->group('custom group', ['my key' => 'my value']);
+
+    $this->assertSame(['key' => 'value'], $this->flare->getGroup());
+    $this->assertSame([], $this->flare->getGroup('foo'));
+    $this->assertSame(['my key' => 'my value'], $this->flare->getGroup('custom group'));
+});
+
+it('can merge groups', function () {
+    $this->flare->group('custom group', ['my key' => 'my value']);
+
+    $this->flare->group('custom group', ['another key' => 'another value']);
+
+    reportException();
+
+    $this->fakeClient->assertLastRequestHas('context.custom group', [
+        'my key' => 'my value',
+        'another key' => 'another value',
+    ]);
+});
+
+it('can set stages', function () {
+    $this->flare->stage('production');
+
+    reportException();
+
+    $this->fakeClient->assertLastRequestHas('stage', 'production');
+});
+
+it('can set message levels', function () {
+    $this->flare->messageLevel('info');
+
+    reportException();
+
+    $this->fakeClient->assertLastRequestHas('message_level', 'info');
+});
+
+it('can add glows', function () {
+    $this->flare->glow(
+        'my glow',
+        MessageLevels::INFO,
+        ['my key' => 'my value']
+    );
+
+    $this->flare->glow(
+        'another glow',
+        MessageLevels::ERROR,
+        ['another key' => 'another value']
+    );
+
+    reportException();
+
+    $payload = $this->fakeClient->getLastPayload();
+
+    $glows = collect($payload['glows'])->map(function ($glow) {
+        unset($glow['microtime']);
+
+        return $glow;
+    })->toArray();
+
+    $this->assertEquals([
+        [
+            'name' => 'my glow',
+            'message_level' => 'info',
+            'meta_data' => ['my key' => 'my value'],
+            'time' => 1546346096,
+        ],
+        [
+            'name' => 'another glow',
+            'message_level' => 'error',
+            'meta_data' => ['another key' => 'another value'],
+            'time' => 1546346096,
+        ],
+    ], $glows);
+});
+
+test('a version callable can be set', function () {
+    $this->assertNull($this->flare->version());
+
+    $this->flare->determineVersionUsing(function () {
+        return '123';
+    });
+
+    $this->assertEquals('123', $this->flare->version());
+});
+
+it('will add the version to the report', function () {
+    reportException();
+
+    $payload = $this->fakeClient->getLastPayload();
+
+    $this->assertNull($payload['application_version']);
+
+    $this->flare->determineVersionUsing(function () {
+        return '123';
+    });
+
+    reportException();
+
+    $payload = $this->fakeClient->getLastPayload();
+
+    $this->assertEquals('123', $payload['application_version']);
+});
+
+it('can filter exceptions being reported', function () {
+    reportException();
+
+    $this->fakeClient->assertRequestsSent(1);
+
+    $this->flare->filterExceptionsUsing(function (Throwable $exception) {
+        return false;
+    });
+
+    reportException();
+
+    $this->fakeClient->assertRequestsSent(1);
+
+    $this->flare->filterExceptionsUsing(function (Throwable $exception) {
+        return true;
+    });
+
+    reportException();
+
+    $this->fakeClient->assertRequestsSent(2);
+});
+
+it('can filter errors based on their level', function () {
+    reportError(E_NOTICE);
+    reportError(E_WARNING);
+
+    $this->fakeClient->assertRequestsSent(2);
+
+    $this->flare->reportErrorLevels(E_ALL & ~E_NOTICE);
+
+    reportError(E_NOTICE);
+    reportError(E_WARNING);
+
+    $this->fakeClient->assertRequestsSent(3);
+});
+
+it('can filter error exceptions based on their severity', function () {
+    $this->flare->report(new ErrorException('test', 0, E_NOTICE));
+    $this->flare->report(new ErrorException('test', 0, E_WARNING));
+
+    $this->fakeClient->assertRequestsSent(2);
+
+    $this->flare->reportErrorLevels(E_ALL & ~E_NOTICE);
+
+    $this->flare->report(new ErrorException('test', 0, E_NOTICE));
+    $this->flare->report(new ErrorException('test', 0, E_WARNING));
+
+    $this->fakeClient->assertRequestsSent(3);
+});
+
+// Helpers
+function reportException()
 {
-    use MatchesReportSnapshots;
+    $throwable = new Exception('This is a test');
 
-    /** @var FakeClient */
-    protected $fakeClient;
+    test()->flare->report($throwable);
+}
 
-    /** @var Flare */
-    protected $flare;
+function reportError(int $code)
+{
+    $throwable = new Error('This is a test', $code);
 
-    public function setUp(): void
-    {
-        parent::setUp();
-
-        $this->fakeClient = new FakeClient();
-
-        $this->flare = new Flare($this->fakeClient);
-
-        $this->useTime('2019-01-01 12:34:56');
-    }
-
-    /* This function at the top so our snapshots won't fail
-     * every time we add a test
-     */
-    protected function reportException()
-    {
-        $throwable = new Exception('This is a test');
-
-        $this->flare->report($throwable);
-    }
-
-    protected function reportError(int $code)
-    {
-        $throwable = new Error('This is a test', $code);
-
-        $this->flare->report($throwable);
-    }
-
-    /** @test */
-    public function it_can_report_an_exception()
-    {
-        $this->reportException();
-
-        $this->fakeClient->assertRequestsSent(1);
-
-        $report = $this->fakeClient->getLastPayload();
-
-        $this->assertMatchesReportSnapshot($report);
-    }
-
-    /** @test */
-    public function it_can_reset_queued_exceptions()
-    {
-        $this->reportException();
-
-        $this->flare->reset();
-
-        $this->fakeClient->assertRequestsSent(1);
-
-        $this->flare->reset();
-
-        $this->fakeClient->assertRequestsSent(1);
-    }
-
-    /** @test */
-    public function it_can_add_user_provided_context()
-    {
-        $this->flare->context('my key', 'my value');
-
-        $this->reportException();
-
-        $this->fakeClient->assertLastRequestHas('context.context', [
-            'my key' => 'my value',
-        ]);
-    }
-
-    /** @test */
-    public function callbacks_can_modify_the_report()
-    {
-        $this->flare->context('my key', 'my value');
-        $this->flare->stage('production');
-        $this->flare->messageLevel('info');
-
-        $throwable = new Exception('This is a test');
-
-        $this->flare->report($throwable, function ($report) {
-            $report->context('my key', 'new value');
-            $report->stage('development');
-            $report->messageLevel('warning');
-        });
-
-        $this->fakeClient->assertLastRequestHas('context.context', [
-            'my key' => 'new value',
-        ]);
-        $this->fakeClient->assertLastRequestHas('stage', 'development');
-        $this->fakeClient->assertLastRequestHas('message_level', 'warning');
-    }
-
-    /** @test */
-    public function it_can_censor_request_data()
-    {
-        $_ENV['FLARE_FAKE_WEB_REQUEST'] = true;
-        $_POST['user'] = 'john@example.com';
-        $_POST['password'] = 'secret';
-
-        $this->flare->censorRequestBodyFields(['user', 'password']);
-
-        $this->reportException();
-
-        $this->fakeClient->assertLastRequestContains('context.request_data.body', [
-            'user' => '<CENSORED>',
-            'password' => '<CENSORED>',
-        ]);
-    }
-
-    /** @test */
-    public function it_can_merge_user_provided_context()
-    {
-        $this->flare->context('my key', 'my value');
-
-        $this->flare->context('another key', 'another value');
-
-        $this->reportException();
-
-        $this->fakeClient->assertLastRequestHas('context.context', [
-            'my key' => 'my value',
-            'another key' => 'another value',
-        ]);
-    }
-
-    /** @test */
-    public function it_can_add_custom_exception_context()
-    {
-        $this->flare->context('my key', 'my value');
-
-        $throwable = new ExceptionWithContext('This is a test');
-
-        $this->flare->report($throwable);
-
-        $this->fakeClient->assertLastRequestHas('context.context', [
-            'my key' => 'my value',
-            'another key' => 'another value',
-        ]);
-    }
-
-    /** @test */
-    public function it_can_add_a_group()
-    {
-        $this->flare->group('custom group', ['my key' => 'my value']);
-
-        $this->reportException();
-
-        $this->fakeClient->assertLastRequestHas('context.custom group', [
-            'my key' => 'my value',
-        ]);
-    }
-
-    /** @test */
-    public function it_can_return_groups()
-    {
-        $this->flare->context('key', 'value');
-
-        $this->flare->group('custom group', ['my key' => 'my value']);
-
-        $this->assertSame(['key' => 'value'], $this->flare->getGroup());
-        $this->assertSame([], $this->flare->getGroup('foo'));
-        $this->assertSame(['my key' => 'my value'], $this->flare->getGroup('custom group'));
-    }
-
-    /** @test */
-    public function it_can_merge_groups()
-    {
-        $this->flare->group('custom group', ['my key' => 'my value']);
-
-        $this->flare->group('custom group', ['another key' => 'another value']);
-
-        $this->reportException();
-
-        $this->fakeClient->assertLastRequestHas('context.custom group', [
-            'my key' => 'my value',
-            'another key' => 'another value',
-        ]);
-    }
-
-    /** @test */
-    public function it_can_set_stages()
-    {
-        $this->flare->stage('production');
-
-        $this->reportException();
-
-        $this->fakeClient->assertLastRequestHas('stage', 'production');
-    }
-
-    /** @test */
-    public function it_can_set_message_levels()
-    {
-        $this->flare->messageLevel('info');
-
-        $this->reportException();
-
-        $this->fakeClient->assertLastRequestHas('message_level', 'info');
-    }
-
-    /** @test */
-    public function it_can_add_glows()
-    {
-        $this->flare->glow(
-            'my glow',
-            MessageLevels::INFO,
-            ['my key' => 'my value']
-        );
-
-        $this->flare->glow(
-            'another glow',
-            MessageLevels::ERROR,
-            ['another key' => 'another value']
-        );
-
-        $this->reportException();
-
-        $payload = $this->fakeClient->getLastPayload();
-
-        $glows = collect($payload['glows'])->map(function ($glow) {
-            unset($glow['microtime']);
-
-            return $glow;
-        })->toArray();
-
-        $this->assertEquals([
-            [
-                'name' => 'my glow',
-                'message_level' => 'info',
-                'meta_data' => ['my key' => 'my value'],
-                'time' => 1546346096,
-            ],
-            [
-                'name' => 'another glow',
-                'message_level' => 'error',
-                'meta_data' => ['another key' => 'another value'],
-                'time' => 1546346096,
-            ],
-        ], $glows);
-    }
-
-    /** @test */
-    public function a_version_callable_can_be_set()
-    {
-        $this->assertNull($this->flare->version());
-
-        $this->flare->determineVersionUsing(function () {
-            return '123';
-        });
-
-        $this->assertEquals('123', $this->flare->version());
-    }
-
-    /** @test */
-    public function it_will_add_the_version_to_the_report()
-    {
-        $this->reportException();
-
-        $payload = $this->fakeClient->getLastPayload();
-
-        $this->assertNull($payload['application_version']);
-
-        $this->flare->determineVersionUsing(function () {
-            return '123';
-        });
-
-        $this->reportException();
-
-        $payload = $this->fakeClient->getLastPayload();
-
-        $this->assertEquals('123', $payload['application_version']);
-    }
-
-    /** @test */
-    public function it_can_filter_exceptions_being_reported()
-    {
-        $this->reportException();
-
-        $this->fakeClient->assertRequestsSent(1);
-
-        $this->flare->filterExceptionsUsing(function (Throwable $exception) {
-            return false;
-        });
-
-        $this->reportException();
-
-        $this->fakeClient->assertRequestsSent(1);
-
-        $this->flare->filterExceptionsUsing(function (Throwable $exception) {
-            return true;
-        });
-
-        $this->reportException();
-
-        $this->fakeClient->assertRequestsSent(2);
-    }
-
-    /** @test */
-    public function it_can_filter_errors_based_on_their_level()
-    {
-        $this->reportError(E_NOTICE);
-        $this->reportError(E_WARNING);
-
-        $this->fakeClient->assertRequestsSent(2);
-
-        $this->flare->reportErrorLevels(E_ALL & ~E_NOTICE);
-
-        $this->reportError(E_NOTICE);
-        $this->reportError(E_WARNING);
-
-        $this->fakeClient->assertRequestsSent(3);
-    }
-
-    /** @test */
-    public function it_can_filter_error_exceptions_based_on_their_severity()
-    {
-        $this->flare->report(new ErrorException('test', 0, E_NOTICE));
-        $this->flare->report(new ErrorException('test', 0, E_WARNING));
-
-        $this->fakeClient->assertRequestsSent(2);
-
-        $this->flare->reportErrorLevels(E_ALL & ~E_NOTICE);
-
-        $this->flare->report(new ErrorException('test', 0, E_NOTICE));
-        $this->flare->report(new ErrorException('test', 0, E_WARNING));
-
-        $this->fakeClient->assertRequestsSent(3);
-    }
+    test()->flare->report($throwable);
 }

--- a/tests/Glows/RecorderTest.php
+++ b/tests/Glows/RecorderTest.php
@@ -1,59 +1,50 @@
 <?php
 
-namespace Spatie\FlareClient\Tests\Glows;
-
 use Spatie\FlareClient\Glows\Glow;
 use Spatie\FlareClient\Glows\GlowRecorder;
 use Spatie\FlareClient\Tests\TestCase;
 
-class RecorderTest extends TestCase
-{
-    /** @test */
-    public function it_is_initially_empty()
-    {
-        $recorder = new GlowRecorder();
+uses(TestCase::class);
 
-        $this->assertCount(0, $recorder->glows());
-    }
+it('is initially empty', function () {
+    $recorder = new GlowRecorder();
 
-    /** @test */
-    public function it_stores_glows()
-    {
-        $recorder = new GlowRecorder();
+    $this->assertCount(0, $recorder->glows());
+});
 
-        $glow = new Glow('Some name', 'info', [
-            'some' => 'metadata',
-        ]);
+it('stores glows', function () {
+    $recorder = new GlowRecorder();
 
-        $recorder->record($glow);
+    $glow = new Glow('Some name', 'info', [
+        'some' => 'metadata',
+    ]);
 
-        $this->assertCount(1, $recorder->glows());
+    $recorder->record($glow);
 
-        $this->assertSame($glow, $recorder->glows()[0]);
-    }
+    $this->assertCount(1, $recorder->glows());
 
-    /** @test */
-    public function it_does_not_store_more_than_the_max_defined_number_of_glows()
-    {
-        $recorder = new GlowRecorder();
+    $this->assertSame($glow, $recorder->glows()[0]);
+});
 
-        $crumb1 = new Glow('One');
-        $crumb2 = new Glow('Two');
+it('does not store more than the max defined number of glows', function () {
+    $recorder = new GlowRecorder();
 
-        foreach (range(1, 40) as $i) {
-            $recorder->record($crumb1);
-        }
+    $crumb1 = new Glow('One');
+    $crumb2 = new Glow('Two');
 
-        $recorder->record($crumb2);
+    foreach (range(1, 40) as $i) {
         $recorder->record($crumb1);
-        $recorder->record($crumb2);
-
-        $this->assertCount(GlowRecorder::GLOW_LIMIT, $recorder->glows());
-
-        $this->assertSame([
-            $crumb1, $crumb1, $crumb1, $crumb1, $crumb1, $crumb1, $crumb1, $crumb1, $crumb1, $crumb1,
-            $crumb1, $crumb1, $crumb1, $crumb1, $crumb1, $crumb1, $crumb1, $crumb1, $crumb1, $crumb1,
-            $crumb1, $crumb1, $crumb1, $crumb1, $crumb1, $crumb1, $crumb1, $crumb2, $crumb1, $crumb2,
-        ], $recorder->glows());
     }
-}
+
+    $recorder->record($crumb2);
+    $recorder->record($crumb1);
+    $recorder->record($crumb2);
+
+    $this->assertCount(GlowRecorder::GLOW_LIMIT, $recorder->glows());
+
+    $this->assertSame([
+        $crumb1, $crumb1, $crumb1, $crumb1, $crumb1, $crumb1, $crumb1, $crumb1, $crumb1, $crumb1,
+        $crumb1, $crumb1, $crumb1, $crumb1, $crumb1, $crumb1, $crumb1, $crumb1, $crumb1, $crumb1,
+        $crumb1, $crumb1, $crumb1, $crumb1, $crumb1, $crumb1, $crumb1, $crumb2, $crumb1, $crumb2,
+    ], $recorder->glows());
+});

--- a/tests/Glows/RecorderTest.php
+++ b/tests/Glows/RecorderTest.php
@@ -9,7 +9,7 @@ uses(TestCase::class);
 it('is initially empty', function () {
     $recorder = new GlowRecorder();
 
-    $this->assertCount(0, $recorder->glows());
+    expect($recorder->glows())->toHaveCount(0);
 });
 
 it('stores glows', function () {
@@ -21,9 +21,9 @@ it('stores glows', function () {
 
     $recorder->record($glow);
 
-    $this->assertCount(1, $recorder->glows());
+    expect($recorder->glows())->toHaveCount(1);
 
-    $this->assertSame($glow, $recorder->glows()[0]);
+    expect($recorder->glows()[0])->toBe($glow);
 });
 
 it('does not store more than the max defined number of glows', function () {
@@ -40,7 +40,7 @@ it('does not store more than the max defined number of glows', function () {
     $recorder->record($crumb1);
     $recorder->record($crumb2);
 
-    $this->assertCount(GlowRecorder::GLOW_LIMIT, $recorder->glows());
+    expect($recorder->glows())->toHaveCount(GlowRecorder::GLOW_LIMIT);
 
     $this->assertSame([
         $crumb1, $crumb1, $crumb1, $crumb1, $crumb1, $crumb1, $crumb1, $crumb1, $crumb1, $crumb1,

--- a/tests/Glows/RecorderTest.php
+++ b/tests/Glows/RecorderTest.php
@@ -2,8 +2,6 @@
 
 use Spatie\FlareClient\Glows\Glow;
 use Spatie\FlareClient\Glows\GlowRecorder;
-use Spatie\FlareClient\Tests\TestCase;
-
 
 it('is initially empty', function () {
     $recorder = new GlowRecorder();

--- a/tests/Glows/RecorderTest.php
+++ b/tests/Glows/RecorderTest.php
@@ -4,7 +4,6 @@ use Spatie\FlareClient\Glows\Glow;
 use Spatie\FlareClient\Glows\GlowRecorder;
 use Spatie\FlareClient\Tests\TestCase;
 
-uses(TestCase::class);
 
 it('is initially empty', function () {
     $recorder = new GlowRecorder();

--- a/tests/Mocks/FakeClient.php
+++ b/tests/Mocks/FakeClient.php
@@ -37,7 +37,8 @@ class FakeClient extends Client
 
         $lastPayload = Arr::last($this->requests)['arguments'];
 
-        Assert::assertTrue(Arr::has($lastPayload, $key), 'The last payload doesnt have the expected key. '.print_r($lastPayload, true));
+
+        Assert::assertTrue(Arr::has($lastPayload, $key), 'The last payload doesnt have the expected key. ');
 
         if ($expectedContent === null) {
             return;
@@ -55,7 +56,7 @@ class FakeClient extends Client
         $lastPayload = Arr::last($this->requests)['arguments'];
 
 
-        Assert::assertTrue(Arr::has($lastPayload, $key), 'The last payload doesnt have the expected key. '.print_r($lastPayload, true));
+        Assert::assertTrue(Arr::has($lastPayload, $key), 'The last payload doesnt have the expected key. ');
 
         if ($expectedContent === null) {
             return;

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -1,0 +1,40 @@
+<?php
+
+/*
+|--------------------------------------------------------------------------
+| Test Case
+|--------------------------------------------------------------------------
+|
+| The closure you provide to your test functions is always bound to a specific PHPUnit test
+| case class. By default, that class is "PHPUnit\Framework\TestCase". Of course, you may
+| need to change it using the "uses()" function to bind a different classes or traits.
+|
+*/
+
+/** @link https://pestphp.com/docs/underlying-test-case */
+
+/*
+|--------------------------------------------------------------------------
+| Expectations
+|--------------------------------------------------------------------------
+|
+| When you're writing tests, you often need to check that values meet certain conditions. The
+| "expect()" function gives you access to a set of "expectations" methods that you can use
+| to assert different things. Of course, you may extend the Expectation API at any time.
+|
+*/
+
+/** @link https://pestphp.com/docs/expectations#custom-expectations */
+
+/*
+|--------------------------------------------------------------------------
+| Functions
+|--------------------------------------------------------------------------
+|
+| While Pest is very powerful out-of-the-box, you may have some testing code specific to your
+| project that you don't want to repeat in every file. Here you can also expose helpers as
+| global functions to help you to reduce the number of lines of code in your test files.
+|
+*/
+
+/** @link https://pestphp.com/docs/helpers */

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -1,5 +1,10 @@
 <?php
 
+uses(\Spatie\FlareClient\Tests\TestCase::class)->in('Context', 'Glows');
+uses(\Spatie\FlareClient\Tests\Concerns\MatchesCodeSnippetSnapshots::class)->in('');
+uses(\TestCase::class)->in('');
+uses(\Spatie\FlareClient\Tests\Concerns\MatchesReportSnapshots::class)->in('');
+
 /*
 |--------------------------------------------------------------------------
 | Test Case

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -1,45 +1,7 @@
 <?php
 
-uses(\Spatie\FlareClient\Tests\TestCase::class)->in('Context', 'Glows');
-uses(\Spatie\FlareClient\Tests\Concerns\MatchesCodeSnippetSnapshots::class)->in('');
-uses(\TestCase::class)->in('');
-uses(\Spatie\FlareClient\Tests\Concerns\MatchesReportSnapshots::class)->in('');
+use Spatie\FlareClient\Tests\TestCase;
 
-/*
-|--------------------------------------------------------------------------
-| Test Case
-|--------------------------------------------------------------------------
-|
-| The closure you provide to your test functions is always bound to a specific PHPUnit test
-| case class. By default, that class is "PHPUnit\Framework\TestCase". Of course, you may
-| need to change it using the "uses()" function to bind a different classes or traits.
-|
-*/
+uses(TestCase::class)->in(__DIR__);
 
-/** @link https://pestphp.com/docs/underlying-test-case */
 
-/*
-|--------------------------------------------------------------------------
-| Expectations
-|--------------------------------------------------------------------------
-|
-| When you're writing tests, you often need to check that values meet certain conditions. The
-| "expect()" function gives you access to a set of "expectations" methods that you can use
-| to assert different things. Of course, you may extend the Expectation API at any time.
-|
-*/
-
-/** @link https://pestphp.com/docs/expectations#custom-expectations */
-
-/*
-|--------------------------------------------------------------------------
-| Functions
-|--------------------------------------------------------------------------
-|
-| While Pest is very powerful out-of-the-box, you may have some testing code specific to your
-| project that you don't want to repeat in every file. Here you can also expose helpers as
-| global functions to help you to reduce the number of lines of code in your test files.
-|
-*/
-
-/** @link https://pestphp.com/docs/helpers */

--- a/tests/ReportTest.php
+++ b/tests/ReportTest.php
@@ -1,7 +1,5 @@
 <?php
 
-namespace Spatie\FlareClient\Tests;
-
 use Exception;
 use Spatie\FlareClient\Context\ConsoleContextProvider;
 use Spatie\FlareClient\Glows\Glow;
@@ -9,73 +7,58 @@ use Spatie\FlareClient\Report;
 use Spatie\FlareClient\Tests\Concerns\MatchesReportSnapshots;
 use Spatie\FlareClient\Tests\TestClasses\FakeTime;
 
-class ReportTest extends TestCase
-{
-    use MatchesReportSnapshots;
+uses(TestCase::class);
+uses(MatchesReportSnapshots::class);
 
-    public function setUp(): void
-    {
-        parent::setUp();
+beforeEach(function () {
+    Report::useTime(new FakeTime('2019-01-01 01:23:45'));
+});
 
-        Report::useTime(new FakeTime('2019-01-01 01:23:45'));
-    }
+it('can create a report', function () {
+    $report = Report::createForThrowable(new Exception('this is an exception'), new ConsoleContextProvider());
 
-    /** @test */
-    public function it_can_create_a_report()
-    {
-        $report = Report::createForThrowable(new Exception('this is an exception'), new ConsoleContextProvider());
+    $report = $report->toArray();
 
-        $report = $report->toArray();
+    $this->assertMatchesReportSnapshot($report);
+});
 
-        $this->assertMatchesReportSnapshot($report);
-    }
+it('will generate a uuid', function () {
+    $report = Report::createForThrowable(new Exception('this is an exception'), new ConsoleContextProvider());
 
-    /** @test */
-    public function it_will_generate_a_uuid()
-    {
-        $report = Report::createForThrowable(new Exception('this is an exception'), new ConsoleContextProvider());
+    $this->assertIsString($report->trackingUuid());
 
-        $this->assertIsString($report->trackingUuid());
+    $this->assertIsString($report->toArray()['tracking_uuid']);
+});
 
-        $this->assertIsString($report->toArray()['tracking_uuid']);
-    }
+it('can create a report for a string message', function () {
+    $report = Report::createForMessage('this is a message', 'Log', new ConsoleContextProvider());
 
-    /** @test */
-    public function it_can_create_a_report_for_a_string_message()
-    {
-        $report = Report::createForMessage('this is a message', 'Log', new ConsoleContextProvider());
+    $report = $report->toArray();
 
-        $report = $report->toArray();
+    $this->assertMatchesReportSnapshot($report);
+});
 
-        $this->assertMatchesReportSnapshot($report);
-    }
+it('can create a report with glows', function () {
+    /** @var Report $report */
+    $report = Report::createForThrowable(new Exception('this is an exception'), new ConsoleContextProvider());
 
-    /** @test */
-    public function it_can_create_a_report_with_glows()
-    {
-        /** @var Report $report */
-        $report = Report::createForThrowable(new Exception('this is an exception'), new ConsoleContextProvider());
+    $report->addGlow(new Glow('Glow 1', 'info', ['meta' => 'data']));
 
-        $report->addGlow(new Glow('Glow 1', 'info', ['meta' => 'data']));
+    $report = $report->toArray();
 
-        $report = $report->toArray();
+    $this->assertMatchesReportSnapshot($report);
+});
 
-        $this->assertMatchesReportSnapshot($report);
-    }
+it('can create a report with meta data', function () {
+    /** @var Report $report */
+    $report = Report::createForThrowable(new Exception('this is an exception'), new ConsoleContextProvider());
 
-    /** @test */
-    public function it_can_create_a_report_with_meta_data()
-    {
-        /** @var Report $report */
-        $report = Report::createForThrowable(new Exception('this is an exception'), new ConsoleContextProvider());
+    $metadata = [
+        'some' => 'data',
+        'something' => 'more',
+    ];
 
-        $metadata = [
-            'some' => 'data',
-            'something' => 'more',
-        ];
+    $report->userProvidedContext(['meta' => $metadata]);
 
-        $report->userProvidedContext(['meta' => $metadata]);
-
-        $this->assertEquals($metadata, $report->toArray()['context']['meta']);
-    }
-}
+    $this->assertEquals($metadata, $report->toArray()['context']['meta']);
+});

--- a/tests/ReportTest.php
+++ b/tests/ReportTest.php
@@ -1,6 +1,5 @@
 <?php
 
-use Exception;
 use Spatie\FlareClient\Context\ConsoleContextProvider;
 use Spatie\FlareClient\Glows\Glow;
 use Spatie\FlareClient\Report;

--- a/tests/ReportTest.php
+++ b/tests/ReportTest.php
@@ -6,7 +6,6 @@ use Spatie\FlareClient\Report;
 use Spatie\FlareClient\Tests\Concerns\MatchesReportSnapshots;
 use Spatie\FlareClient\Tests\TestClasses\FakeTime;
 
-uses(TestCase::class);
 uses(MatchesReportSnapshots::class);
 
 beforeEach(function () {

--- a/tests/ReportTest.php
+++ b/tests/ReportTest.php
@@ -24,9 +24,9 @@ it('can create a report', function () {
 it('will generate a uuid', function () {
     $report = Report::createForThrowable(new Exception('this is an exception'), new ConsoleContextProvider());
 
-    $this->assertIsString($report->trackingUuid());
+    expect($report->trackingUuid())->toBeString();
 
-    $this->assertIsString($report->toArray()['tracking_uuid']);
+    expect($report->toArray()['tracking_uuid'])->toBeString();
 });
 
 it('can create a report for a string message', function () {
@@ -59,5 +59,5 @@ it('can create a report with meta data', function () {
 
     $report->userProvidedContext(['meta' => $metadata]);
 
-    $this->assertEquals($metadata, $report->toArray()['context']['meta']);
+    expect($report->toArray()['context']['meta'])->toEqual($metadata);
 });

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -9,7 +9,7 @@ use Spatie\FlareClient\Tests\TestClasses\FakeTime;
 
 class TestCase extends BaseTestCase
 {
-    public function setUp(): void
+    protected function setUp(): void
     {
         parent::setUp();
 

--- a/tests/Truncation/TrimContextItemsStrategyTest.php
+++ b/tests/Truncation/TrimContextItemsStrategyTest.php
@@ -14,7 +14,7 @@ it('can trim long context items in payload', function () {
         [$payload, $expected] = createLargePayload($threshold);
 
         $strategy = new TrimContextItemsStrategy(new ReportTrimmer());
-        $this->assertSame($expected, $strategy->execute($payload));
+        expect($strategy->execute($payload))->toBe($expected);
     }
 });
 
@@ -31,7 +31,7 @@ it('does not trim short payloads', function () {
 
     $trimmedPayload = $strategy->execute($payload);
 
-    $this->assertSame($payload, $trimmedPayload);
+    expect($trimmedPayload)->toBe($payload);
 });
 
 // Helpers

--- a/tests/Truncation/TrimContextItemsStrategyTest.php
+++ b/tests/Truncation/TrimContextItemsStrategyTest.php
@@ -11,7 +11,7 @@ beforeEach(function () {
 
 it('can trim long context items in payload', function () {
     foreach (TrimContextItemsStrategy::thresholds() as $threshold) {
-        [$payload, $expected] = createLargePayload($threshold);
+        [$payload, $expected] = createLargePayloadWithContext($threshold);
 
         $strategy = new TrimContextItemsStrategy(new ReportTrimmer());
         expect($strategy->execute($payload))->toBe($expected);
@@ -35,7 +35,7 @@ it('does not trim short payloads', function () {
 });
 
 // Helpers
-function createLargePayload($threshold)
+function createLargePayloadWithContext($threshold)
 {
     $payload = $expected = [
         'context' => [

--- a/tests/Truncation/TrimStringsStrategyTest.php
+++ b/tests/Truncation/TrimStringsStrategyTest.php
@@ -1,56 +1,48 @@
 <?php
 
-namespace Spatie\FlareClient\Tests\Truncation;
 
-use PHPUnit\Framework\TestCase;
 use Spatie\FlareClient\Truncation\ReportTrimmer;
 use Spatie\FlareClient\Truncation\TrimStringsStrategy;
 
-class TrimStringsStrategyTest extends TestCase
-{
-    /** @test */
-    public function it_can_trim_long_strings_in_payload()
-    {
-        foreach (TrimStringsStrategy::thresholds() as $threshold) {
-            [$payload, $expected] = $this->createLargePayload($threshold);
-
-            $strategy = new TrimStringsStrategy(new ReportTrimmer());
-            $this->assertSame($expected, $strategy->execute($payload));
-        }
-    }
-
-    /** @test */
-    public function it_does_not_trim_short_payloads()
-    {
-        $payload = [
-            'data' => [
-                'body' => 'short',
-                'nested' => [
-                    'message' => 'short',
-                ],
-            ],
-        ];
+it('can trim long strings in payload', function () {
+    foreach (TrimStringsStrategy::thresholds() as $threshold) {
+        [$payload, $expected] = createLargePayload($threshold);
 
         $strategy = new TrimStringsStrategy(new ReportTrimmer());
-
-        $trimmedPayload = $strategy->execute($payload);
-
-        $this->assertSame($payload, $trimmedPayload);
+        $this->assertSame($expected, $strategy->execute($payload));
     }
+});
 
-    protected function createLargePayload($threshold)
-    {
-        $payload = $expected = [
-            'data' => [
-                'messages' => [],
+it('does not trim short payloads', function () {
+    $payload = [
+        'data' => [
+            'body' => 'short',
+            'nested' => [
+                'message' => 'short',
             ],
-        ];
+        ],
+    ];
 
-        while (strlen(json_encode($payload)) < ReportTrimmer::getMaxPayloadSize()) {
-            $payload['data']['messages'][] = str_repeat('A', $threshold + 10);
-            $expected['data']['messages'][] = str_repeat('A', $threshold);
-        }
+    $strategy = new TrimStringsStrategy(new ReportTrimmer());
 
-        return [$payload, $expected];
+    $trimmedPayload = $strategy->execute($payload);
+
+    $this->assertSame($payload, $trimmedPayload);
+});
+
+// Helpers
+function createLargePayload($threshold)
+{
+    $payload = $expected = [
+        'data' => [
+            'messages' => [],
+        ],
+    ];
+
+    while (strlen(json_encode($payload)) < ReportTrimmer::getMaxPayloadSize()) {
+        $payload['data']['messages'][] = str_repeat('A', $threshold + 10);
+        $expected['data']['messages'][] = str_repeat('A', $threshold);
     }
+
+    return [$payload, $expected];
 }

--- a/tests/Truncation/TrimStringsStrategyTest.php
+++ b/tests/Truncation/TrimStringsStrategyTest.php
@@ -9,7 +9,7 @@ it('can trim long strings in payload', function () {
         [$payload, $expected] = createLargePayload($threshold);
 
         $strategy = new TrimStringsStrategy(new ReportTrimmer());
-        $this->assertSame($expected, $strategy->execute($payload));
+        expect($strategy->execute($payload))->toBe($expected);
     }
 });
 
@@ -27,7 +27,7 @@ it('does not trim short payloads', function () {
 
     $trimmedPayload = $strategy->execute($payload);
 
-    $this->assertSame($payload, $trimmedPayload);
+    expect($trimmedPayload)->toBe($payload);
 });
 
 // Helpers


### PR DESCRIPTION
This pull request contains changes for migrating your test suite from PHPUnit to [Pest](https://pestphp.com/) automated by the [Pest Converter](https://laravelshift.com/phpunit-to-pest-converter).

**Before merging**, you need to:

- Checkout the `shift-52828` branch
- Review **all** of the comments below for additional changes
- Run `composer update` to install Pest with your dependencies
- Run `vendor/bin/pest` to verify the conversion
