### PR TITLE
catch throwable instead of exception for getSession failure

### DIFF
--- a/src/Context/RequestContextProvider.php
+++ b/src/Context/RequestContextProvider.php
@@ -86,7 +86,7 @@ class RequestContextProvider implements ContextProvider
     {
         try {
             $session = $this->request->getSession();
-        } catch (Exception $exception) {
+        } catch (Throwable $exception) {
             $session = [];
         }
 


### PR DESCRIPTION
The following was erroring for me in latest version of L9 - I'd not run my migration files after pruning my docker containers.

```
[2022-02-28 09:31:26] local.ERROR: Uncaught Error: Object of type Illuminate\Session\Store is not callable in /var/www/html/vendor/symfony/http-foundation/Request.php:698
Stack trace:
#0 /var/www/html/vendor/spatie/flare-client-php/src/Context/RequestContextProvider.php(88): Symfony\Component\HttpFoundation\Request->getSession()
#1 /var/www/html/vendor/spatie/flare-client-php/src/Context/RequestContextProvider.php(147): Spatie\FlareClient\Context\RequestContextProvider->getSession()
#2 /var/www/html/vendor/spatie/laravel-ignition/src/ContextProviders/LaravelRequestContextProvider.php(90): Spatie\FlareClient\Context\RequestContextProvider->toArray()
#3 /var/www/html/vendor/spatie/flare-client-php/src/Report.php(280): Spatie\LaravelIgnition\ContextProviders\LaravelRequestContextProvider->toArray()
```