### PR TITLE
Add support for report filtering

### DIFF
--- a/src/Flare.php
+++ b/src/Flare.php
@@ -52,6 +52,9 @@ class Flare
     /** @var null|callable */
     protected $filterExceptionsCallable = null;
 
+    /** @var null|callable */
+    protected $filterReportsCallable = null;
+
     protected ?string $stage = null;
 
     protected ?string $requestId = null;
@@ -117,6 +120,13 @@ class Flare
     public function filterExceptionsUsing(callable $filterExceptionsCallable): self
     {
         $this->filterExceptionsCallable = $filterExceptionsCallable;
+
+        return $this;
+    }
+
+    public function filterReportsUsing(callable $filterReportsCallable): self
+    {
+        $this->filterReportsCallable = $filterReportsCallable;
 
         return $this;
     }
@@ -330,6 +340,12 @@ class Flare
 
     protected function sendReportToApi(Report $report): void
     {
+        if ($this->filterReportsCallable) {
+            if (! call_user_func($this->filterReportsCallable, $report)) {
+                return;
+            }
+        }
+
         try {
             $this->api->report($report);
         } catch (Exception $exception) {


### PR DESCRIPTION
Adds the ability to prevent reports from being sent.

The motivation behind it that we need a way to dynamically allow/disallow reports from being sent, for example based on if git tree is clean, which can be compute heavy and cannot be done during boot.

Compared to `filterExceptionsCallable` it can also prevent logs and errors from being sent, and that's why it's in `sendReportToApi()` instead of `shouldSendReport()`

Usage is something like this:
```
Flare::filterReportsUsing(function(Report $report) {
  return false;
});
```