### PR TITLE
Add callable type to docblock

### DIFF
--- a/src/Flare.php
+++ b/src/Flare.php
@@ -212,7 +212,7 @@ class Flare
     }
 
     /**
-     * @param FlareMiddleware|array<FlareMiddleware>|class-string<FlareMiddleware> $middleware
+     * @param FlareMiddleware|array<FlareMiddleware>|class-string<FlareMiddleware>|callable $middleware
      *
      * @return $this
      */


### PR DESCRIPTION
As documented here https://flareapp.io/docs/ignition-for-laravel/writing-custom-middleware you can pass a callable to `registerMiddleware()`

I have changed the docblock to reflect this.