### PR TITLE
[1.x] Tests against PHP 8.3 and adds Symfony 7 support

### DIFF
--- a/.github/workflows/php-cs-fixer.yml
+++ b/.github/workflows/php-cs-fixer.yml
@@ -8,7 +8,7 @@ jobs:
 
         steps:
             -   name: Checkout code
-                uses: actions/checkout@v2
+                uses: actions/checkout@v4
 
             -   name: Fix style
                 uses: docker://oskarstark/php-cs-fixer-ga

--- a/.github/workflows/phpstan.yml
+++ b/.github/workflows/phpstan.yml
@@ -16,7 +16,7 @@ jobs:
     name: phpstan
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -8,7 +8,7 @@ jobs:
 
         strategy:
             matrix:
-                php: [8.2, 8.1, 8.0]
+                php: [8.3, 8.2, 8.1, 8.0]
                 dependency-version: [prefer-lowest, prefer-stable]
                 os: [ubuntu-latest]
 
@@ -16,7 +16,7 @@ jobs:
 
         steps:
             - name: Checkout code
-              uses: actions/checkout@v2
+              uses: actions/checkout@v4
 
             - name: Setup PHP
               uses: shivammathur/setup-php@v2

--- a/.github/workflows/update-changelog.yml
+++ b/.github/workflows/update-changelog.yml
@@ -10,7 +10,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           ref: main
 

--- a/composer.json
+++ b/composer.json
@@ -11,21 +11,21 @@
     "license": "MIT",
     "require": {
         "php": "^8.0",
-        "illuminate/pipeline": "^8.0|^9.0|^10.0",
+        "illuminate/pipeline": "^8.0|^9.0|^10.0|^11.0",
         "spatie/backtrace": "^1.5.2",
-        "symfony/http-foundation": "^5.0|^6.0",
-        "symfony/mime": "^5.2|^6.0",
-        "symfony/process": "^5.2|^6.0",
-        "symfony/var-dumper": "^5.2|^6.0",
+        "symfony/http-foundation": "^5.2|^6.0|^7.0",
+        "symfony/mime": "^5.2|^6.0|^7.0",
+        "symfony/process": "^5.2|^6.0|^7.0",
+        "symfony/var-dumper": "^5.2|^6.0|^7.0",
         "nesbot/carbon": "^2.62.1"
     },
     "require-dev": {
-        "dms/phpunit-arraysubset-asserts": "^0.3.0",
+        "dms/phpunit-arraysubset-asserts": "^0.5.0",
         "phpstan/extension-installer": "^1.1",
         "phpstan/phpstan-deprecation-rules": "^1.0",
         "phpstan/phpstan-phpunit": "^1.0",
-        "spatie/phpunit-snapshot-assertions": "^4.0",
-        "pestphp/pest": "^1.20"
+        "spatie/phpunit-snapshot-assertions": "^4.0|^5.0",
+        "pestphp/pest": "^1.20|^2.0"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
This pull request tests Flare PHP Client against PHP 8.3 and adds Symfony 7 support.

Can you also tag, once this is merged please?