### PR TITLE
Fix editor url by removing starting slash from the file path

### DIFF
--- a/src/Frame.php
+++ b/src/Frame.php
@@ -20,7 +20,7 @@ class Frame
     public function toArray(): array
     {
         return [
-            'file' => $this->frame->file,
+            'file' => ltrim($this->frame->file, '/'),,
             'line_number' => $this->frame->lineNumber,
             'method' => $this->frame->method,
             'class' => $this->frame->class,


### PR DESCRIPTION
I tried to use the editor link feature but it didn't work.
So I started checking the link...

The actual link:
```
vscode://file/%2Fmnt%2Fntfs%2FDev%2Fwww%2FSomething%2Froutes%2Fweb.php:13
```
After my change:
```
vscode://file/mnt%2Fntfs%2FDev%2Fwww%2FSomething%2Froutes%2Fweb.php:13
```
And now it's working.

I don't know if I'm not mistaken or this is the best way to fix it. @freekmurze 
Regards.
<hr>

_OS: Linux(Ubuntu)
PHP: 8.3.3
Laravel: 10.39.0
Environment: Local
Browser: Brave/Firefox_