### PR TITLE
Fix incorrect argument order when calling previous error handler

### DIFF
--- a/src/Flare.php
+++ b/src/Flare.php
@@ -295,8 +295,8 @@ class Flare
         if ($this->previousErrorHandler) {
             return call_user_func(
                 $this->previousErrorHandler,
-                $message,
                 $code,
+                $message,
                 $file,
                 $line
             );


### PR DESCRIPTION
Think this is the correct argument order, see here: https://www.php.net/manual/en/function.set-error-handler.php#refsect1-function.set-error-handler-parameters

Easy way to reproduce is if you set `previousErrorHandler` to Ignition error handler, you should get a _Argument #1 ($level) must be of type int, string given_ error