### PR TITLE
Fix PHP 8.4 deprecation errors

### DIFF
--- a/src/Context/RequestContextProvider.php
+++ b/src/Context/RequestContextProvider.php
@@ -14,7 +14,7 @@ class RequestContextProvider implements ContextProvider
 {
     protected ?Request $request;
 
-    public function __construct(Request $request = null)
+    public function __construct(?Request $request = null)
     {
         $this->request = $request ?? Request::createFromGlobals();
     }

--- a/src/Flare.php
+++ b/src/Flare.php
@@ -69,8 +69,8 @@ class Flare
     protected bool $withStackFrameArguments = true;
 
     public static function make(
-        string $apiKey = null,
-        ContextProviderDetector $contextDetector = null
+        ?string $apiKey = null,
+        ?ContextProviderDetector $contextDetector = null
     ): self {
         $client = new Client($apiKey);
 
@@ -175,7 +175,7 @@ class Flare
      */
     public function __construct(
         Client $client,
-        ContextProviderDetector $contextDetector = null,
+        ?ContextProviderDetector $contextDetector = null,
         array $middleware = [],
     ) {
         $this->client = $client;
@@ -317,7 +317,7 @@ class Flare
         return $this;
     }
 
-    public function report(Throwable $throwable, callable $callback = null, Report $report = null, ?bool $handled = null): ?Report
+    public function report(Throwable $throwable, ?callable $callback = null, ?Report $report = null, ?bool $handled = null): ?Report
     {
         if (! $this->shouldSendReport($throwable)) {
             return null;
@@ -362,7 +362,7 @@ class Flare
         return true;
     }
 
-    public function reportMessage(string $message, string $logLevel, callable $callback = null): void
+    public function reportMessage(string $message, string $logLevel, ?callable $callback = null): void
     {
         $report = $this->createReportFromMessage($message, $logLevel);
 

--- a/tests/TestClasses/FakeTime.php
+++ b/tests/TestClasses/FakeTime.php
@@ -10,7 +10,7 @@ class FakeTime implements Time
     /** @var \DateTimeImmutable */
     protected $dateTime;
 
-    public function __construct(string $dateTime = null, $format = 'Y-m-d H:i:s')
+    public function __construct(?string $dateTime = null, $format = 'Y-m-d H:i:s')
     {
         if (! is_null($dateTime)) {
             $this->setCurrentTime($dateTime, $format);


### PR DESCRIPTION
Hi:

Implicitly nullable parameter declarations deprecated in PHP 8.4.

I don't know if it fixed all, but it fixed my tests.