### PR TITLE
Fixed PHP 8.4 deprecation warnings

### DIFF
--- a/src/Flare.php
+++ b/src/Flare.php
@@ -69,8 +69,8 @@ class Flare
     protected bool $withStackFrameArguments = true;
 
     public static function make(
-        string $apiKey = null,
-        ContextProviderDetector $contextDetector = null
+        ?string $apiKey = null,
+        ?ContextProviderDetector $contextDetector = null
     ): self {
         $client = new Client($apiKey);
 
@@ -175,7 +175,7 @@ class Flare
      */
     public function __construct(
         Client $client,
-        ContextProviderDetector $contextDetector = null,
+        ?ContextProviderDetector $contextDetector = null,
         array $middleware = [],
     ) {
         $this->client = $client;
@@ -317,7 +317,7 @@ class Flare
         return $this;
     }
 
-    public function report(Throwable $throwable, callable $callback = null, Report $report = null, ?bool $handled = null): ?Report
+    public function report(Throwable $throwable, ?callable $callback = null, ?Report $report = null, ?bool $handled = null): ?Report
     {
         if (! $this->shouldSendReport($throwable)) {
             return null;
@@ -362,7 +362,7 @@ class Flare
         return true;
     }
 
-    public function reportMessage(string $message, string $logLevel, callable $callback = null): void
+    public function reportMessage(string $message, string $logLevel, ?callable $callback = null): void
     {
         $report = $this->createReportFromMessage($message, $logLevel);
 


### PR DESCRIPTION
After upgrade from PHP 8.3 to 8.4 I get this deprecation errors on laravel deprecated log.

```
PHP Deprecated:  Spatie\FlareClient\Flare::__construct(): Implicitly marking parameter $contextDetector as nullable is deprecated, the explicit nullable type must be used instead in vendor/spatie/flare-client-php/src/Flare.php on line 176
PHP Deprecated:  Spatie\FlareClient\Flare::make(): Implicitly marking parameter $apiKey as nullable is deprecated, the explicit nullable type must be used instead in vendor/spatie/flare-client-php/src/Flare.php on line 71
PHP Deprecated:  Spatie\FlareClient\Flare::make(): Implicitly marking parameter $contextDetector as nullable is deprecated, the explicit nullable type must be used instead in vendor/spatie/flare-client-php/src/Flare.php on line 71
PHP Deprecated:  Spatie\FlareClient\Flare::report(): Implicitly marking parameter $callback as nullable is deprecated, the explicit nullable type must be used instead in vendor/spatie/flare-client-php/src/Flare.php on line 320
PHP Deprecated:  Spatie\FlareClient\Flare::report(): Implicitly marking parameter $report as nullable is deprecated, the explicit nullable type must be used instead in vendor/spatie/flare-client-php/src/Flare.php on line 320
PHP Deprecated:  Spatie\FlareClient\Flare::reportMessage(): Implicitly marking parameter $callback as nullable is deprecated, the explicit nullable type must be used instead in vendor/spatie/flare-client-php/src/Flare.php on line 365
```