### PR TITLE
Supports Laravel 12

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     "license": "MIT",
     "require": {
         "php": "^8.0",
-        "illuminate/pipeline": "^8.0|^9.0|^10.0|^11.0",
+        "illuminate/pipeline": "^8.0|^9.0|^10.0|^11.0|^12.0",
         "spatie/backtrace": "^1.6.1",
         "symfony/http-foundation": "^5.2|^6.0|^7.0",
         "symfony/mime": "^5.2|^6.0|^7.0",


### PR DESCRIPTION
This pull request updates the version constraint for `illuminate/pipeline` in order to support Laravel 12, which is due to be released on 24th February. It doesn't include any breaking changes.