### PR TITLE
Fix for composer format

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,6 +22,7 @@
         "symfony/var-dumper": "^5.2|^6.0|^7.0"
     },
     "require-dev": {
+        "friendsofphp/php-cs-fixer": "^3.89",
         "pestphp/pest": "^2.36.0|^3.0|^4.0",
         "phpstan/extension-installer": "^1.4",
         "phpstan/phpstan-deprecation-rules": "^1.2",
@@ -42,7 +43,7 @@
     "scripts": {
         "analyse": "vendor/bin/phpstan analyse",
         "baseline": "vendor/bin/phpstan analyse --generate-baseline",
-        "format": "vendor/bin/php-cs-fixer fix --allow-risky=yes",
+        "format": "vendor/bin/php-cs-fixer fix --allow-risky=yes --config=.php_cs.php",
         "test": "vendor/bin/pest",
         "test-coverage": "vendor/bin/phpunit --coverage-html coverage"
     },


### PR DESCRIPTION
## Issue
Running composer format on a fresh clone fails.

- The script is missing on a fresh install
```sh
sh: vendor/bin/php-cs-fixer: No such file or directory
Script vendor/bin/php-cs-fixer fix --allow-risky=yes handling the format event returned with error code 127
```
- After adding `php-cs-fixer` the script fails with:
```sh
PHP CS Fixer 3.89.2 Folding Bike by Fabien Potencier, Dariusz Ruminski and contributors.
PHP runtime: 8.2.28
Running analysis on 1 core sequentially.
You can enable parallel runner and speed up the analysis! Please see usage docs for more information.
Loaded config default.
Using cache file ".php-cs-fixer.cache".

In Finder.php line 667:

  You must call one of in() or append() methods before iterating over a Finder.


fix [--path-mode PATH-MODE] [--allow-risky ALLOW-RISKY] [--config CONFIG] [--dry-run] [--rules RULES] [--using-cache USING-CACHE] [--allow-unsupported-php-version ALLOW-UNSUPPORTED-PHP-VERSION] [--cache-file CACHE-FILE] [--diff] [--format FORMAT] [--stop-on-violation] [--show-progress SHOW-PROGRESS] [--sequential] [--] [<path>...]

Script vendor/bin/php-cs-fixer fix --allow-risky=yes handling the format event returned with error code 1
```

## Changes
- Added `friendsofphp/php-cs-fixer` to devDependencies
- Updated the script specifying the project's configuration

These were based on the github action.