### PR TITLE
Handle non-JSON responses in CurlSender gracefully

### DIFF
--- a/src/Senders/CurlSender.php
+++ b/src/Senders/CurlSender.php
@@ -48,7 +48,7 @@ class CurlSender implements Sender
             curl_setopt($curlHandle, $option, $value);
         }
 
-        $rawResponse = curl_exec($curlHandle);
+        $rawResponse = $this->executeCurl($curlHandle);
 
         if (is_bool($rawResponse)) {
             throw new ConnectionError(curl_error($curlHandle));
@@ -68,6 +68,11 @@ class CurlSender implements Sender
         }
 
         $callback(new Response($headers['http_code'], $body));
+    }
+
+    protected function executeCurl(CurlHandle $curlHandle): string|bool
+    {
+        return curl_exec($curlHandle);
     }
 
     protected function getCurlHandle(string $fullUrl, array $headers = []): CurlHandle

--- a/src/Senders/GuzzleSender.php
+++ b/src/Senders/GuzzleSender.php
@@ -4,6 +4,7 @@ namespace Spatie\FlareClient\Senders;
 
 use Closure;
 use GuzzleHttp\Client;
+use Psr\Http\Message\ResponseInterface;
 use Spatie\FlareClient\Enums\FlarePayloadType;
 use Spatie\FlareClient\Senders\Support\Response;
 
@@ -19,14 +20,7 @@ class GuzzleSender implements Sender
 
     public function post(string $endpoint, string $apiToken, array $payload, FlarePayloadType $type, Closure $callback): void
     {
-        $response = $this->client->post($endpoint, [
-            'headers' => [
-                'Accept' => 'application/json',
-                'Content-Type' => 'application/json',
-                'x-api-token' => $apiToken,
-            ],
-            'json' => $payload,
-        ]);
+        $response = $this->executeRequest($endpoint, $apiToken, $payload);
 
         $rawResponse = $response->getBody()->getContents();
 
@@ -40,5 +34,17 @@ class GuzzleSender implements Sender
             $response->getStatusCode(),
             $body,
         ));
+    }
+
+    protected function executeRequest(string $endpoint, string $apiToken, array $payload): ResponseInterface
+    {
+        return $this->client->post($endpoint, [
+            'headers' => [
+                'Accept' => 'application/json',
+                'Content-Type' => 'application/json',
+                'x-api-token' => $apiToken,
+            ],
+            'json' => $payload,
+        ]);
     }
 }

--- a/tests/Senders/CurlSenderTest.php
+++ b/tests/Senders/CurlSenderTest.php
@@ -1,0 +1,89 @@
+<?php
+
+use Spatie\FlareClient\Enums\FlarePayloadType;
+use Spatie\FlareClient\Senders\CurlSender;
+use Spatie\FlareClient\Senders\Exceptions\ConnectionError;
+use Spatie\FlareClient\Senders\Support\Response;
+
+class TestCurlSender extends CurlSender
+{
+    public string|bool $fakeResponse = '';
+
+    protected function executeCurl(CurlHandle $curlHandle): string|bool
+    {
+        return $this->fakeResponse;
+    }
+}
+
+it('does not throw when receiving an empty response body', function () {
+    $sender = new TestCurlSender();
+    $sender->fakeResponse = '';
+
+    $response = null;
+
+    $sender->post(
+        'https://example.com/api',
+        'fake-api-key',
+        ['test' => 'payload'],
+        FlarePayloadType::Error,
+        function (Response $r) use (&$response) {
+            $response = $r;
+        }
+    );
+
+    expect($response)->toBeInstanceOf(Response::class);
+    expect($response->body)->toBe('');
+});
+
+it('does not throw when receiving a non-JSON response body', function () {
+    $sender = new TestCurlSender();
+    $sender->fakeResponse = 'OK';
+
+    $response = null;
+
+    $sender->post(
+        'https://example.com/api',
+        'fake-api-key',
+        ['test' => 'payload'],
+        FlarePayloadType::Error,
+        function (Response $r) use (&$response) {
+            $response = $r;
+        }
+    );
+
+    expect($response)->toBeInstanceOf(Response::class);
+    expect($response->body)->toBe('OK');
+});
+
+it('still parses valid JSON responses into arrays', function () {
+    $sender = new TestCurlSender();
+    $sender->fakeResponse = '{"message":"success"}';
+
+    $response = null;
+
+    $sender->post(
+        'https://example.com/api',
+        'fake-api-key',
+        ['test' => 'payload'],
+        FlarePayloadType::Error,
+        function (Response $r) use (&$response) {
+            $response = $r;
+        }
+    );
+
+    expect($response)->toBeInstanceOf(Response::class);
+    expect($response->body)->toBe(['message' => 'success']);
+});
+
+it('still throws ConnectionError when curl_exec returns false', function () {
+    $sender = new TestCurlSender();
+    $sender->fakeResponse = false;
+
+    $sender->post(
+        'https://example.com/api',
+        'fake-api-key',
+        ['test' => 'payload'],
+        FlarePayloadType::Error,
+        function (Response $r) {}
+    );
+})->throws(ConnectionError::class);

--- a/tests/Senders/GuzzleSenderTest.php
+++ b/tests/Senders/GuzzleSenderTest.php
@@ -1,0 +1,84 @@
+<?php
+
+use GuzzleHttp\Psr7\Response as GuzzleResponse;
+use Psr\Http\Message\ResponseInterface;
+use Spatie\FlareClient\Enums\FlarePayloadType;
+use Spatie\FlareClient\Senders\GuzzleSender;
+use Spatie\FlareClient\Senders\Support\Response;
+
+class TestGuzzleSender extends GuzzleSender
+{
+    public GuzzleResponse $fakeResponse;
+
+    public function __construct()
+    {
+        parent::__construct();
+
+        $this->fakeResponse = new GuzzleResponse(200, [], '');
+    }
+
+    protected function executeRequest(string $endpoint, string $apiToken, array $payload): ResponseInterface
+    {
+        return $this->fakeResponse;
+    }
+}
+
+it('does not throw when receiving an empty response body', function () {
+    $sender = new TestGuzzleSender();
+    $sender->fakeResponse = new GuzzleResponse(200, [], '');
+
+    $response = null;
+
+    $sender->post(
+        'https://example.com/api',
+        'fake-api-key',
+        ['test' => 'payload'],
+        FlarePayloadType::Error,
+        function (Response $r) use (&$response) {
+            $response = $r;
+        }
+    );
+
+    expect($response)->toBeInstanceOf(Response::class);
+    expect($response->body)->toBe('');
+});
+
+it('does not throw when receiving a non-JSON response body', function () {
+    $sender = new TestGuzzleSender();
+    $sender->fakeResponse = new GuzzleResponse(200, [], 'OK');
+
+    $response = null;
+
+    $sender->post(
+        'https://example.com/api',
+        'fake-api-key',
+        ['test' => 'payload'],
+        FlarePayloadType::Error,
+        function (Response $r) use (&$response) {
+            $response = $r;
+        }
+    );
+
+    expect($response)->toBeInstanceOf(Response::class);
+    expect($response->body)->toBe('OK');
+});
+
+it('still parses valid JSON responses into arrays', function () {
+    $sender = new TestGuzzleSender();
+    $sender->fakeResponse = new GuzzleResponse(200, [], '{"message":"success"}');
+
+    $response = null;
+
+    $sender->post(
+        'https://example.com/api',
+        'fake-api-key',
+        ['test' => 'payload'],
+        FlarePayloadType::Error,
+        function (Response $r) use (&$response) {
+            $response = $r;
+        }
+    );
+
+    expect($response)->toBeInstanceOf(Response::class);
+    expect($response->body)->toBe(['message' => 'success']);
+});


### PR DESCRIPTION
`CurlSender::post()` strictly validated the API response as JSON, throwing a ConnectionError on empty or non-JSON bodies, even when the HTTP request succeeds.

This was masked for normal `Api::report()` calls (which silently catch all exceptions), but `Api::test()` has no try/catch, so the ConnectionError propagated up to the caller. In configs that use `CurlSender`, this broke
`flare:test`. The command would report a connection error despite the request having succeeded.

The fix replaces the `json_decode` + `json_last_error` check with `json_decode($json, true) ?? $json`, matching what `LaravelHttpSender` already does. Valid JSON is decoded to an array; anything else passes through as a raw string. `Response::$body` is typed mixed, so both are fine.

Also extracts a protected `executeCurl()` method as a testing seam and adds unit tests covering empty bodies, non-JSON bodies, valid JSON, and curl failures.