### PR TITLE
Normalise trailing slashes for forPath and forUrl sampling rules

### DIFF
--- a/src/Sampling/SamplingRule.php
+++ b/src/Sampling/SamplingRule.php
@@ -108,6 +108,11 @@ class SamplingRule
             default => $entryPoint->handlerIdentifier,
         };
 
+        if ($this->type === SamplingRuleType::Path || $this->type === SamplingRuleType::Url) {
+            $value = rtrim($value, '/') ?: '/';
+            $pattern = rtrim($pattern, '/') ?: '/';
+        }
+
         return PatternMatcher::matches($value, $pattern) ? $this->rate : null;
     }
 }

--- a/tests/Sampling/SamplingRuleTest.php
+++ b/tests/Sampling/SamplingRuleTest.php
@@ -155,6 +155,16 @@ it('returns the matched rate when the entry point matches', function (SamplingRu
         new EntryPoint(EntryPointType::Web, 'https://example.com'),
         0.42,
     ],
+    'path pattern matches value with trailing slash' => fn () => [
+        SamplingRule::forPath('/foo', 1.0),
+        new EntryPoint(EntryPointType::Web, 'https://example.com/foo/'),
+        1.0,
+    ],
+    'url pattern matches value with trailing slash' => fn () => [
+        SamplingRule::forUrl('https://example.com/foo', 1.0),
+        new EntryPoint(EntryPointType::Web, 'https://example.com/foo/'),
+        1.0,
+    ],
     'route handler without method prefix uses full identifier' => function () {
         $entryPoint = new EntryPoint(EntryPointType::Web, 'https://example.com/users');
 


### PR DESCRIPTION
## Summary

- A path filter for `/foo` would not trigger on an incoming `/foo/` (or vice versa) because `PatternMatcher` anchors the regex.
- `forPath` and `forUrl` rules now strip the trailing slash from both the pattern and the matched value before matching, so a single pattern handles both shapes. Root paths are preserved.
- `forRoute`, `forCommand`, and `forJob` are untouched; they don't carry URL-style paths.