### PR TITLE
Tie trace ids to active lifetime, add Flare::start()/end()

### DIFF
--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -2,6 +2,18 @@
 
 There are some breaking changes you should be aware of. We've categorized them so you can prioritize. This guide covers the most common cases. Edge cases may not be covered, and PRs to improve it are welcome.
 
+## From v3.0 to v3.1
+
+`Tracer::currentTraceId()`, `currentSpanId()`, and `traceParent()` now return `?string`, with `null` when no trace is active. Recorders skip silently without an active trace instead of recording orphan spans.
+
+If you use `spatie/laravel-flare` no changes are needed. For framework agnostic apps, replace `registerFlareHandlers()` with `$flare->start()`, which also opens the lifecycle:
+
+```php
+$flare = Flare::make($config)->start();
+```
+
+For subtask mode (queue workers, long-running processes), keep using `$flare->lifecycle->startSubtask()` per work unit.
+
 ## From v2 to v3
 
 The new version of the package adds better support for logging and tracing lifetimes. We don't expect upgrading to require a lot of code changes for typical applications.

--- a/src/Flare.php
+++ b/src/Flare.php
@@ -64,6 +64,41 @@ class Flare
         return $container->get(Flare::class);
     }
 
+    public function start(
+        ?int $timeUnixNano = null,
+        array $attributes = [],
+        ?string $traceparent = null,
+    ): self {
+        if ($this->lifecycle->usesSubtasks) {
+            throw new Exception(
+                'Flare::start() is for the main lifecycle. In subtask mode, use $flare->lifecycle->startSubtask() per work unit.'
+            );
+        }
+
+        $this->reporter->registerFlareHandlers();
+        $this->lifecycle->start($timeUnixNano, $attributes, $traceparent);
+
+        return $this;
+    }
+
+    public function end(
+        ?int $timeUnixNano = null,
+        array $additionalTerminationAttributes = [],
+        array $additionalApplicationAttributes = [],
+    ): void {
+        if ($this->lifecycle->usesSubtasks) {
+            throw new Exception(
+                'Flare::end() is for the main lifecycle. In subtask mode, use $flare->lifecycle->endSubtask() per work unit.'
+            );
+        }
+
+        $this->lifecycle->terminated(
+            $timeUnixNano,
+            $additionalTerminationAttributes,
+            $additionalApplicationAttributes,
+        );
+    }
+
     public function registerFlareHandlers(): self
     {
         $this->reporter->registerFlareHandlers();

--- a/src/Recorders/SpansRecorder.php
+++ b/src/Recorders/SpansRecorder.php
@@ -86,6 +86,12 @@ abstract class SpansRecorder extends Recorder implements SpansRecorderContract
             return null;
         }
 
+        $currentTraceId = $this->tracer->currentTraceId();
+
+        if ($currentTraceId === null) {
+            return null;
+        }
+
         if ($nameAndAttributes !== null) {
             ['name' => $name, 'attributes' => $attributes] = $nameAndAttributes();
         } else {
@@ -98,7 +104,7 @@ abstract class SpansRecorder extends Recorder implements SpansRecorderContract
         $spanId = $this->tracer->nextSpanId();
 
         $span = new Span(
-            traceId: $this->tracer->currentTraceId(),
+            traceId: $currentTraceId,
             spanId: $spanId,
             parentSpanId: $parentSpanId,
             name: $name,

--- a/src/Support/Lifecycle.php
+++ b/src/Support/Lifecycle.php
@@ -324,6 +324,8 @@ class Lifecycle
         $this->stage = LifecycleStage::Terminated;
 
         if ($this->tracer->sampling === false) {
+            $this->tracer->endTrace();
+
             return;
         }
 

--- a/src/Tracer.php
+++ b/src/Tracer.php
@@ -36,11 +36,11 @@ class Tracer
     /** @var array @param array{max_spans: int, max_attributes_per_span: int, max_span_events_per_span: int, max_attributes_per_span_event: int}|null */
     public readonly array $limits;
 
-    protected string $currentTraceId;
+    protected ?string $currentTraceId = null;
 
-    protected string $currentSpanId;
+    protected ?string $currentSpanId = null;
 
-    protected bool $currentSpanIdAvailable;
+    protected bool $currentSpanIdAvailable = true;
 
     /**
      * @param array{max_spans: int, max_attributes_per_span: int, max_span_events_per_span: int, max_attributes_per_span_event: int}|null $limits
@@ -64,10 +64,6 @@ class Tracer
         public readonly bool $disabled = false,
         protected Closure|null $gracefulSpanEnderClosure = null,
     ) {
-        $this->currentTraceId = $this->ids->trace();
-        $this->currentSpanId = $this->ids->span();
-        $this->currentSpanIdAvailable = true;
-
         $this->limits = [
             'max_spans' => $limits['max_spans'] ?? self::DEFAULT_MAX_SPANS_LIMIT,
             'max_attributes_per_span' => $limits['max_attributes_per_span'] ?? self::DEFAULT_MAX_ATTRIBUTES_PER_SPAN_LIMIT,
@@ -81,35 +77,38 @@ class Tracer
         ?string $spanId = null,
         ?string $traceParent = null,
     ): bool {
-        if ($this->disabled === true) {
-            return false;
-        }
-
-        if ($this->sampling) {
+        if ($this->currentTraceId !== null) {
             return $this->sampling;
-        }
-
-        $parentSampled = null;
-
-        if ($traceParent !== null) {
-            $parsed = $this->ids->parseTraceparent($traceParent);
-
-            if ($parsed !== null) {
-                $traceId = $parsed['traceId'];
-                $spanId = $parsed['parentSpanId'];
-                $parentSampled = $parsed['sampling'];
-            }
         }
 
         if (($traceId === null) !== ($spanId === null)) {
             throw new Exception('If one of traceId or spanId is provided, both must be provided.');
         }
 
+        $parentSampled = null;
+        $currentSpanAvailable = true;
+
+        $parsedTraceParent = $traceParent !== null
+            ? $this->ids->parseTraceparent($traceParent)
+            : null;
+
         if ($traceId !== null && $spanId !== null) {
-            $this->currentTraceId = $traceId;
-            $this->currentSpanId = $spanId;
-            $this->currentSpanIdAvailable = false;
-            $this->spans = [];
+            $currentSpanAvailable = false;
+        }
+
+        if ($parsedTraceParent) {
+            $traceId = $parsedTraceParent['traceId'];
+            $spanId = $parsedTraceParent['parentSpanId'];
+            $parentSampled = $parsedTraceParent['sampling'];
+            $currentSpanAvailable = false;
+        }
+
+        $this->currentTraceId = $traceId ?? $this->ids->trace();
+        $this->currentSpanId = $spanId ?? $this->ids->span();
+        $this->currentSpanIdAvailable = $currentSpanAvailable;
+
+        if ($this->disabled === true) {
+            return false;
         }
 
         return $this->sampling = $this->sampler->shouldSample(
@@ -124,12 +123,8 @@ class Tracer
             $this->sampler->reset();
         }
 
-        if ($this->sampling === false) {
-            return;
-        }
-
-        $this->currentTraceId = $this->ids->trace();
-        $this->currentSpanId = $this->ids->span();
+        $this->currentTraceId = null;
+        $this->currentSpanId = null;
         $this->currentSpanIdAvailable = true;
         $this->sampling = false;
 
@@ -173,11 +168,8 @@ class Tracer
         }
 
         $this->paused = false;
-
-        if ($this->sampling === false) {
-            return;
-        }
-
+        $this->currentTraceId = null;
+        $this->currentSpanId = null;
         $this->currentSpanIdAvailable = true;
         $this->sampling = false;
         $this->spans = [];
@@ -213,12 +205,12 @@ class Tracer
         return $this->paused;
     }
 
-    public function currentTraceId(): string
+    public function currentTraceId(): ?string
     {
         return $this->currentTraceId;
     }
 
-    public function currentSpanId(): string
+    public function currentSpanId(): ?string
     {
         return $this->currentSpanId;
     }
@@ -232,7 +224,7 @@ class Tracer
 
     public function nextSpanId(): string
     {
-        if ($this->sampling && $this->currentSpanIdAvailable === true) {
+        if ($this->sampling && $this->currentSpanIdAvailable === true && $this->currentSpanId !== null) {
             $this->currentSpanIdAvailable = false;
 
             return $this->currentSpanId;
@@ -241,11 +233,15 @@ class Tracer
         return $this->ids->span();
     }
 
-    public function traceParent(): string
+    public function traceParent(): ?string
     {
+        if ($this->currentTraceId === null || $this->currentSpanId === null) {
+            return null;
+        }
+
         return $this->ids->traceParent(
-            $this->currentTraceId ?? '',
-            $this->currentSpanId ?? '',
+            $this->currentTraceId,
+            $this->currentSpanId,
             $this->isSampling(),
         );
     }
@@ -283,6 +279,10 @@ class Tracer
 
     public function currentSpan(): ?Span
     {
+        if ($this->currentSpanId === null) {
+            return null;
+        }
+
         return $this->spans[$this->currentSpanId] ?? null;
     }
 
@@ -312,12 +312,16 @@ class Tracer
         ?int $time = null,
         array $attributes = [],
     ): Span|AddSpanResult {
+        if ($this->currentTraceId === null) {
+            throw new Exception('Cannot start a span without an active trace.');
+        }
+
         // Order of operations is important here, do not inline!
         $parentSpanId = $this->currentParentSpanId();
         $spanId = $this->nextSpanId();
 
         $span = new Span(
-            traceId: $this->currentTraceId ?? $this->ids->trace(),
+            traceId: $this->currentTraceId,
             spanId: $spanId,
             parentSpanId: $parentSpanId,
             name: $name,

--- a/tests/FlareTest.php
+++ b/tests/FlareTest.php
@@ -43,6 +43,16 @@ it('can report an exception', function () {
     );
 });
 
+it('can start and end a flare lifecycle', function () {
+    $flare = setupFlare(alwaysSampleTraces: true)->start();
+
+    expect($flare->tracer->isSampling())->toBeTrue();
+
+    $flare->end();
+
+    expect($flare->tracer->isSampling())->toBeFalse();
+});
+
 
 it('can reset queued exceptions', function () {
     $flare = setupFlare(fn (FlareConfig $config) => $config->collectContext());
@@ -375,6 +385,8 @@ it('can add logs', function () {
 it('can add queries', function () {
     $flare = setupFlare(fn (FlareConfig $config) => $config->collectQueries());
 
+    $flare->tracer->startTrace();
+
     $flare->query()->record(
         'select * from users where id = ?',
         TimeHelper::milliseconds(250),
@@ -423,6 +435,8 @@ it('can add queries', function () {
 it('can begin and commit transactions', function () {
     $flare = setupFlare(fn (FlareConfig $config) => $config->collectTransactions());
 
+    $flare->tracer->startTrace();
+
     $flare->transaction()->recordBegin();
 
     FakeTime::setup('2019-01-01 12:34:57'); // One second later 1546346097000000
@@ -445,6 +459,8 @@ it('can begin and commit transactions', function () {
 
 it('can begin and rollback transactions', function () {
     $flare = setupFlare(fn (FlareConfig $config) => $config->collectTransactions());
+
+    $flare->tracer->startTrace();
 
     $flare->transaction()->recordBegin();
 
@@ -830,6 +846,8 @@ it('can add an additional recorders', function () {
             ],
         ])
     );
+
+    $flare->tracer->startTrace();
 
     $flare->recorder('spans')->record('Hi', duration: TimeHelper::milliseconds(300));
 

--- a/tests/Recorders/QueryRecorder/QueryRecorderTest.php
+++ b/tests/Recorders/QueryRecorder/QueryRecorderTest.php
@@ -235,6 +235,8 @@ it('will not find the origin of a query when only reporting', function () {
         ]
     );
 
+    $flare->tracer->startTrace();
+
     $recorder->record('select * from users where id = ?', TimeHelper::milliseconds(299), ['id' => 1], 'users', 'mysql');
 
     expect($recorder->getSpans())->toHaveCount(1);

--- a/tests/Recorders/SpanEventsRecorderTest.php
+++ b/tests/Recorders/SpanEventsRecorderTest.php
@@ -124,6 +124,8 @@ it('will not trace span events when there is no current span', function () {
         'with_traces' => true,
     ]);
 
+    $flare->tracer->startTrace();
+
     $span = $flare->tracer->startSpan(
         'root span'
     );
@@ -235,6 +237,8 @@ it('will not find origins when tracing events when find origin is disabled', fun
         'with_traces' => true,
         'find_origin' => false,
     ]);
+
+    $flare->tracer->startTrace();
 
     $span = $flare->tracer->startSpan('Parent Span');
 

--- a/tests/Recorders/SpansRecorderTest.php
+++ b/tests/Recorders/SpansRecorderTest.php
@@ -42,6 +42,8 @@ it('can report a span with tracing disabled', function () {
         'with_traces' => false,
     ]);
 
+    $flare->tracer->startTrace();
+
     $recorder->record('Span', 100);
 
     $spans = $recorder->getSpans();
@@ -65,6 +67,8 @@ it('does not store more than the max defined number of reported spans and remove
         'max_items_with_errors' => 35,
     ]);
 
+    $flare->tracer->startTrace();
+
     foreach (range(1, 40) as $i) {
         $recorder->pushSpan("Span - Hello {$i}");
         $recorder->popSpan();
@@ -82,6 +86,8 @@ it('can disable the limit of spans stored for reporting', function () {
         'with_errors' => true,
         'max_items_with_errors' => null,
     ]);
+
+    $flare->tracer->startTrace();
 
     foreach (range(1, 250) as $i) {
         $recorder->pushSpan("Hello {$i}");
@@ -163,6 +169,8 @@ it('a closure passed span will not be executed when not tracing or reporting', f
     }
 
     $flare = setupFlare(alwaysSampleTraces: true);
+
+    $flare->tracer->startTrace();
 
     expect(fn () => (new TestConcreteSpanRecorderExecution($flare->tracer, $flare->backTracer, config: [
         'with_traces' => true,

--- a/tests/TracerTest.php
+++ b/tests/TracerTest.php
@@ -241,17 +241,16 @@ it('can start a span resuming a propagated trace', function () {
     expect($span->spanId)->not()->toBeNull();
 });
 
-it('can unsample a trace and all its spans', function () {
+it('can unsample a trace and clear its state', function () {
     $tracer = setupFlare(alwaysSampleTraces: true)->tracer;
 
     $tracer->startTrace();
-
-    $span = $tracer->startSpan('Some span');
+    $tracer->startSpan('Some span');
 
     $tracer->unsample();
 
-    expect($tracer->currentTraceId())->toBe($span->traceId);
-    expect($tracer->currentSpanId())->toBe($span->spanId);
+    expect($tracer->currentTraceId())->toBeNull();
+    expect($tracer->currentSpanId())->toBeNull();
     expect($tracer->sampling)->toBeFalse();
     expect($tracer->currentTrace())->toBeEmpty();
 });
@@ -387,27 +386,70 @@ it('can remove a span event', function () {
     expect($span->events[0]->name)->toEqual('Some event');
 });
 
-it('will always have a trace and span id even when a trace start call has not happened yet', function () {
+it('has no trace and span id before startTrace is called', function () {
     $tracer = setupFlare()->tracer;
 
-    expect($tracer->currentTraceId())->not()->toBeNull();
-    expect($tracer->currentSpanId())->not()->toBeNull();
+    expect($tracer->currentTraceId())->toBeNull();
+    expect($tracer->currentSpanId())->toBeNull();
 });
 
-it('will use the initial trace and span id until a trace is started', function () {
+it('clears the trace and span id when a sampled trace ends', function () {
     $tracer = setupFlare(alwaysSampleTraces: true)->tracer;
 
-    expect($tracer->currentTraceId())->not()->toBeNull();
-    expect($tracer->currentSpanId())->not()->toBeNull();
+    $tracer->startTrace();
+    $tracer->startSpan('Some span');
+    $tracer->endSpan();
+    $tracer->endTrace();
 
-    $currentTraceId = $tracer->currentTraceId();
-    $currentSpanId = $tracer->currentSpanId();
+    expect($tracer->currentTraceId())->toBeNull();
+    expect($tracer->currentSpanId())->toBeNull();
+});
+
+
+it('preserves the active trace when startTrace is called again on an unsampled trace', function () {
+    $tracer = setupFlare(fn (FlareConfig $config) => $config->sampler(NeverSampler::class))->tracer;
 
     $tracer->startTrace();
-    $span = $tracer->startSpan('Some span');
 
-    expect($span->traceId)->toBe($currentTraceId);
-    expect($span->spanId)->toBe($currentSpanId);
+    $firstTraceId = $tracer->currentTraceId();
+    $firstSpanId = $tracer->currentSpanId();
+
+    $tracer->startTrace();
+
+    expect($tracer->currentTraceId())->toBe($firstTraceId);
+    expect($tracer->currentSpanId())->toBe($firstSpanId);
+});
+
+it('adopts an inbound traceparent even when the tracer is disabled so logs stay correlated', function () {
+    $tracer = setupFlare(fn (FlareConfig $config) => $config->trace = false)->tracer;
+
+    $tracer->startTrace(traceParent: '00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01');
+
+    expect($tracer->sampling)->toBeFalse();
+    expect($tracer->currentTraceId())->toBe('0af7651916cd43dd8448eb211c80319c');
+    expect($tracer->currentSpanId())->toBe('b7ad6b7169203331');
+});
+
+it('returns a null traceparent when there is no active trace context', function () {
+    $tracer = setupFlare()->tracer;
+
+    expect($tracer->traceParent())->toBeNull();
+});
+
+it('returns a traceparent with the local sampling flag when a trace context exists', function () {
+    $tracer = setupFlare(alwaysSampleTraces: true)->tracer;
+
+    $tracer->startTrace();
+
+    expect($tracer->traceParent())->toMatch('/^00-[0-9a-f]{32}-[0-9a-f]{16}-01$/');
+});
+
+it('propagates an inherited traceparent for downstream services even when not sampling locally', function () {
+    $tracer = setupFlare(fn (FlareConfig $config) => $config->trace = false)->tracer;
+
+    $tracer->startTrace(traceParent: '00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01');
+
+    expect($tracer->traceParent())->toMatch('/^00-0af7651916cd43dd8448eb211c80319c-[0-9a-f]{16}-00$/');
 });
 
 it('can include the peak memory usage when ending a span', function () {


### PR DESCRIPTION
## Summary

Fixes a correlation bug where the boot-time `traceId`/`spanId` persisted whenever a trace was not actively sampling. In long-lived processes (queue workers, Octane, or any setup with tracing disabled), every error and log across every request carried the same ids, so the backend could not distinguish one logical unit of work from another. Adds a `Flare::start()` / `Flare::end()` convenience that replaces the `registerFlareHandlers()` + manual `lifecycle->start()` pair in the framework-agnostic install path.

## Trace context lifecycle

The ids now mirror the active-trace lifetime, with no fabricated values during gaps:

- The `Tracer` no longer pre-generates ids in the constructor. `currentTraceId` and `currentSpanId` start as `null` and are typed `?string`.
- `startTrace()` generates fresh ids on every call, is idempotent while a trace is active (`currentTraceId !== null`), and adopts an inbound `traceparent` even when the tracer is disabled so logs stay correlated.
- `endTrace()` and `unsample()` clear the ids unconditionally.
- `Lifecycle::terminated()` now always calls `endTrace()`, including for unsampled traces, so the trace context is always cleaned up between iterations.
- `traceParent()` returns `?string`; null when there is no active context. The sampling flag in the emitted header reflects the local sampling decision, so an inherited inbound trace still propagates to downstream services even when the local tracer is disabled.

## Recorders

`SpansRecorder` now skips when there is no active trace. Recorders consume trace context, they don't fabricate it. Tests that bypass Lifecycle now call `$tracer->startTrace()` explicitly.

## Convenience API

- `Flare::start()` registers the global error handlers and opens the lifecycle in a single call. Throws in subtask mode (with a clear message pointing to `lifecycle->startSubtask()`).
- `Flare::end()` finalises the lifecycle. Optional, the shutdown handler still covers process exit.

The PHP install snippets, UPGRADING.md and the v3 doc pages now recommend `$flare->start()`. Older client versions on the install guides are unchanged.

## Behaviour change

Reading `currentTraceId()` before `startTrace()` returns `null` instead of a freshly generated id. `traceParent()` returns `null` instead of fabricating a string when there is no active context. Callers should null-check before forwarding the header to downstream services.

For applications using `spatie/laravel-flare`, no changes are required. The companion laravel-flare PR adds explicit `startTrace()` calls to the four tests that bypass `setupFlare`'s Lifecycle path.