### PR TITLE
Fix previous throwable stacktrace using the wrong exception's frames

### DIFF
--- a/src/ReportFactory.php
+++ b/src/ReportFactory.php
@@ -176,7 +176,7 @@ class ReportFactory implements WithAttributes
             'exceptionClass' => $this->throwable::class,
             'seenAtUnixNano' => $this->time->getCurrentTime(),
             'message' => $this->message,
-            'stacktrace' => $this->stacktraceMapper->map($this->buildStacktrace(), $this->throwable),
+            'stacktrace' => $this->stacktraceMapper->map($this->buildStacktrace($this->throwable), $this->throwable),
             'previous' => $this->buildPrevious(),
             'openFrameIndex' => null,
             'applicationPath' => $this->applicationPath,
@@ -210,7 +210,7 @@ class ReportFactory implements WithAttributes
             $previous[] = [
                 'exceptionClass' => $previousThrowable::class,
                 'message' => $previousThrowable->getMessage(),
-                'stacktrace' => $this->stacktraceMapper->map($this->buildStacktrace(), $previousThrowable),
+                'stacktrace' => $this->stacktraceMapper->map($this->buildStacktrace($previousThrowable), $previousThrowable),
             ];
 
             $current = $previousThrowable;
@@ -220,9 +220,9 @@ class ReportFactory implements WithAttributes
     }
 
     /** @return array<Frame> */
-    protected function buildStacktrace(): array
+    protected function buildStacktrace(Throwable $throwable): array
     {
-        $frames = Backtrace::createForThrowable($this->throwable)
+        $frames = Backtrace::createForThrowable($throwable)
             ->withArguments($this->collectStackTraceArguments)
             ->reduceArguments($this->argumentReducers)
             ->applicationPath($this->applicationPath ?? '')

--- a/tests/ReportTest.php
+++ b/tests/ReportTest.php
@@ -112,7 +112,9 @@ it('can create entries for previous exceptions', function () {
     $flare = setupFlare();
 
     $rootException = new InvalidArgumentException('This is the root cause exception');
+    $rootLine = __LINE__ - 1;
     $childException = new RuntimeException('This is the previous exception', previous: $rootException);
+    $childLine = __LINE__ - 1;
     $reportedException = new Exception('This is the main exception', previous: $childException);
 
     $flare->report($reportedException);
@@ -124,10 +126,10 @@ it('can create entries for previous exceptions', function () {
     $report->expectPrevious(0)
         ->expectExceptionClass(RuntimeException::class)
         ->expectMessage('This is the previous exception')
-        ->expectStacktraceFrame(0)->expectFile(__FILE__);
+        ->expectStacktraceFrame(0)->expectFile(__FILE__)->expectLineNumber($childLine);
 
     $report->expectPrevious(1)
         ->expectExceptionClass(InvalidArgumentException::class)
         ->expectMessage('This is the root cause exception')
-        ->expectStacktraceFrame(0)->expectFile(__FILE__);
+        ->expectStacktraceFrame(0)->expectFile(__FILE__)->expectLineNumber($rootLine);
 });


### PR DESCRIPTION
`ReportFactory::buildStacktrace()` was hardcoded to build frames from the main throwable, so every "previous" exception entry in a report shipped the main exception's stack trace instead of its own (the class and message were correct, but the frames were wrong). This also meant `ErrorException` frame cleanup and any per-throwable frame rewriting (such as laravel-flare's blade view mapping) were discarded for previous exceptions. The method now takes the throwable as a parameter, and each previous entry builds its stacktrace from its own throwable. The existing test is strengthened to assert each previous entry's frame line number, which fails against the old behaviour.