### PR TITLE
Strip embedded credentials from git remote URL

### DIFF
--- a/src/AttributesProviders/GitAttributesProvider.php
+++ b/src/AttributesProviders/GitAttributesProvider.php
@@ -58,7 +58,7 @@ class GitAttributesProvider implements AttributesProvider
 
         if ($config = file_get_contents($gitDirectory.'/config')) {
             if (preg_match('/\[remote "origin"\][^[]*url\s*=\s*(.+?)$/m', $config, $matches)) {
-                $data['git.remote'] = trim($matches[1]);
+                $data['git.remote'] = $this->sanitizeRemoteUrl(trim($matches[1]));
             }
         }
 
@@ -156,12 +156,21 @@ BASH;
             'git.hash' => $parts[0] ?: null,
             'git.message' => $parts[1] ?: null,
             'git.tag' => $parts[2] ?: null,
-            'git.remote' => $parts[3] ?: null,
+            'git.remote' => $parts[3] ? $this->sanitizeRemoteUrl($parts[3]) : null,
             'git.branch' => $parts[4] ?: null,
             'git.is_dirty' => $parts[5] === 'dirty',
         ];
 
         return array_filter($data, fn ($value) => is_bool($value) || $value !== null);
+    }
+
+    protected function sanitizeRemoteUrl(string $url): string
+    {
+        if (! preg_match('#^(https?://)[^/]*@(.+)$#i', $url, $matches)) {
+            return $url;
+        }
+
+        return $matches[1].$matches[2];
     }
 
     protected function getGitBaseDirectory(): ?string

--- a/tests/AttributesProviders/GitAttributesProviderTest.php
+++ b/tests/AttributesProviders/GitAttributesProviderTest.php
@@ -73,6 +73,25 @@ it('file-based and process-based modes return same commit message when available
     }
 });
 
+it('strips embedded credentials from the git remote url', function () {
+    $baseDirectory = sys_get_temp_dir().'/flare-git-'.uniqid();
+    mkdir($baseDirectory.'/.git', 0777, true);
+    file_put_contents($baseDirectory.'/.git/HEAD', str_repeat('a', 40));
+    file_put_contents($baseDirectory.'/.git/config', <<<'CONFIG'
+        [remote "origin"]
+            url = https://user:password@development.intern.securepoint.de/vtigercrm/vtigercrm.git
+        CONFIG);
+
+    $result = (new GitAttributesProvider(applicationPath: $baseDirectory, useProcess: false))->toArray();
+
+    expect($result['git.remote'])->toBe('https://development.intern.securepoint.de/vtigercrm/vtigercrm.git');
+
+    unlink($baseDirectory.'/.git/HEAD');
+    unlink($baseDirectory.'/.git/config');
+    rmdir($baseDirectory.'/.git');
+    rmdir($baseDirectory);
+});
+
 it('returns empty array when path does not have git directory', function () {
     $provider = new GitAttributesProvider(applicationPath: sys_get_temp_dir(), useProcess: false);
     $result = $provider->toArray();


### PR DESCRIPTION
`GitAttributesProvider` reported `remote.origin.url` verbatim, so a remote like `https://user:password@host/repo.git` leaked its credentials to Flare and into shared error links. Both collection paths (file-based and process-based) now route the URL through a `sanitizeRemoteUrl` helper that strips the userinfo component from `http(s)` URLs, while leaving SSH/SCP URLs untouched since there the userinfo is a login name, not a secret. Added a test covering the credentialed-URL case.