### PR TITLE
Support PHP 8.1

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -8,7 +8,7 @@ jobs:
 
         strategy:
             matrix:
-                php: [8.5, 8.4, 8.3, 8.2]
+                php: [8.5, 8.4, 8.3, 8.2, 8.1]
                 dependency-version: [prefer-lowest, prefer-stable]
                 os: [ubuntu-latest]
 

--- a/composer.json
+++ b/composer.json
@@ -56,6 +56,11 @@
         "allow-plugins": {
             "pestphp/pest-plugin": true,
             "phpstan/extension-installer": true
+        },
+        "policy": {
+            "advisories": {
+                "block": false
+            }
         }
     },
     "prefer-stable": true,

--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
     "homepage": "https://github.com/spatie/flare-client-php",
     "license": "MIT",
     "require": {
-        "php": "^8.2",
+        "php": "^8.1",
         "ext-curl": "*",
         "guzzlehttp/guzzle": "^7.9",
         "monolog/monolog": "^3.0",

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
         "psr/container": "^2.0",
         "spatie/backtrace": "^1.8.0",
         "symfony/console": "^5.2|^6.0|^7.0|^8.0",
-        "spatie/flare-daemon": "^0.1|^0.2",
+        "spatie/flare-daemon": "^0.3",
         "symfony/http-foundation": "^5.2|^6.0|^7.0|^8.0",
         "symfony/mime": "^5.2|^6.0|^7.0|^8.0",
         "symfony/process": "^5.2|^6.0|^7.0|^8.0",

--- a/composer.json
+++ b/composer.json
@@ -59,7 +59,7 @@
         },
         "policy": {
             "advisories": {
-                "block": false
+                "ignore-id": ["PKSA-z3gr-8qht-p93v"]
             }
         }
     },

--- a/src/Memory/SystemMemory.php
+++ b/src/Memory/SystemMemory.php
@@ -11,10 +11,16 @@ class SystemMemory implements Memory
 
     public function resetPeakMemoryUsage(): void
     {
-        if (PHP_VERSION_ID < 80200) {
+        if (! self::phpVersionCanTrackMemory()) {
             return;
         }
 
         memory_reset_peak_usage();
+    }
+
+    public static function phpVersionCanTrackMemory(): bool
+    {
+        // memory_reset_peak_usage() only exists on PHP 8.2+, so peak memory cannot be scoped per span before then
+        return PHP_VERSION_ID >= 80200;
     }
 }

--- a/src/Memory/SystemMemory.php
+++ b/src/Memory/SystemMemory.php
@@ -11,6 +11,10 @@ class SystemMemory implements Memory
 
     public function resetPeakMemoryUsage(): void
     {
+        if (PHP_VERSION_ID < 80200) {
+            return;
+        }
+
         memory_reset_peak_usage();
     }
 }

--- a/src/Tracer.php
+++ b/src/Tracer.php
@@ -365,7 +365,8 @@ class Tracer
             $span->addAttributes($additionalAttributes);
         }
 
-        if ($includeMemoryUsage) {
+        // memory_reset_peak_usage() only exists on PHP 8.2+, so peak memory cannot be scoped per span before then
+        if ($includeMemoryUsage && PHP_VERSION_ID >= 80200) {
             $span->addAttribute('flare.peak_memory_usage', $this->memory->getPeakMemoryUsage());
         }
 

--- a/src/Tracer.php
+++ b/src/Tracer.php
@@ -10,6 +10,7 @@ use Spatie\FlareClient\Enums\AddSpanResult;
 use Spatie\FlareClient\Enums\RecorderType;
 use Spatie\FlareClient\Enums\SpanStatusCode;
 use Spatie\FlareClient\Memory\Memory;
+use Spatie\FlareClient\Memory\SystemMemory;
 use Spatie\FlareClient\Recorders\ContextRecorder\ContextRecorder;
 use Spatie\FlareClient\Sampling\DeferrableSampler;
 use Spatie\FlareClient\Sampling\RateSampler;
@@ -365,8 +366,7 @@ class Tracer
             $span->addAttributes($additionalAttributes);
         }
 
-        // memory_reset_peak_usage() only exists on PHP 8.2+, so peak memory cannot be scoped per span before then
-        if ($includeMemoryUsage && PHP_VERSION_ID >= 80200) {
+        if ($includeMemoryUsage && SystemMemory::phpVersionCanTrackMemory()) {
             $span->addAttribute('flare.peak_memory_usage', $this->memory->getPeakMemoryUsage());
         }
 

--- a/tests/Recorders/CommandRecorder/CommandRecorderTest.php
+++ b/tests/Recorders/CommandRecorder/CommandRecorderTest.php
@@ -5,6 +5,7 @@ use Spatie\FlareClient\EntryPoint\EntryPointResolver;
 use Spatie\FlareClient\Enums\EntryPointType;
 use Spatie\FlareClient\Enums\SpanType;
 use Spatie\FlareClient\FlareConfig;
+use Spatie\FlareClient\Memory\SystemMemory;
 use Spatie\FlareClient\Support\Container;
 use Spatie\FlareClient\Tests\Shared\FakeApi;
 use Spatie\FlareClient\Tests\Shared\FakeMemory;
@@ -62,7 +63,7 @@ it('records the exit code and peak memory usage on recordEnd', function () {
         ->toHaveKey('process.exit_code', 2)
         ->toHaveKey('flare.peak_memory_usage', 7 * 1024 * 1024)
         ->toHaveKey('custom.key', 'value');
-})->skip(PHP_VERSION_ID < 80200, 'Peak memory usage cannot be tracked before PHP 8.2');
+})->skip(! SystemMemory::phpVersionCanTrackMemory(), 'Peak memory usage cannot be tracked before PHP 8.2');
 
 it('records a span from a Symfony InputInterface', function () {
     $flare = setupFlare(fn (FlareConfig $config) => $config->collectCommands(), alwaysSampleTraces: true);

--- a/tests/Recorders/CommandRecorder/CommandRecorderTest.php
+++ b/tests/Recorders/CommandRecorder/CommandRecorderTest.php
@@ -62,7 +62,7 @@ it('records the exit code and peak memory usage on recordEnd', function () {
         ->toHaveKey('process.exit_code', 2)
         ->toHaveKey('flare.peak_memory_usage', 7 * 1024 * 1024)
         ->toHaveKey('custom.key', 'value');
-});
+})->skip(PHP_VERSION_ID < 80200, 'Peak memory usage cannot be tracked before PHP 8.2');
 
 it('records a span from a Symfony InputInterface', function () {
     $flare = setupFlare(fn (FlareConfig $config) => $config->collectCommands(), alwaysSampleTraces: true);

--- a/tests/Recorders/JobRecorder/JobRecorderTest.php
+++ b/tests/Recorders/JobRecorder/JobRecorderTest.php
@@ -6,6 +6,7 @@ use Spatie\FlareClient\Enums\SpanStatusCode;
 use Spatie\FlareClient\Enums\SpanType;
 use Spatie\FlareClient\FlareConfig;
 use Spatie\FlareClient\FlareMiddleware\AddJobInformation;
+use Spatie\FlareClient\Memory\SystemMemory;
 use Spatie\FlareClient\Tests\Shared\FakeIds;
 use Spatie\FlareClient\Tests\Shared\FakeMemory;
 
@@ -99,7 +100,7 @@ it('records the end of a job and includes peak memory usage', function () {
     expect($span->attributes)
         ->toHaveKey('flare.peak_memory_usage', 8 * 1024 * 1024)
         ->toHaveKey('custom.key', 'value');
-})->skip(PHP_VERSION_ID < 80200, 'Peak memory usage cannot be tracked before PHP 8.2');
+})->skip(! SystemMemory::phpVersionCanTrackMemory(), 'Peak memory usage cannot be tracked before PHP 8.2');
 
 it('pauses sampling for an ignored job by name and resumes after recordEnd in non-subtask mode', function () {
     $flare = setupFlare(

--- a/tests/Recorders/JobRecorder/JobRecorderTest.php
+++ b/tests/Recorders/JobRecorder/JobRecorderTest.php
@@ -99,7 +99,7 @@ it('records the end of a job and includes peak memory usage', function () {
     expect($span->attributes)
         ->toHaveKey('flare.peak_memory_usage', 8 * 1024 * 1024)
         ->toHaveKey('custom.key', 'value');
-});
+})->skip(PHP_VERSION_ID < 80200, 'Peak memory usage cannot be tracked before PHP 8.2');
 
 it('pauses sampling for an ignored job by name and resumes after recordEnd in non-subtask mode', function () {
     $flare = setupFlare(

--- a/tests/Recorders/RequestRecorder/RequestRecorderTest.php
+++ b/tests/Recorders/RequestRecorder/RequestRecorderTest.php
@@ -29,8 +29,11 @@ it('can trace requests', function () {
         ->traceId->toBe($flare->tracer->currentTraceId());
 
     expect($span->attributes)
-        ->toHaveKey('flare.span_type', SpanType::Request)
-        ->toHaveKey('flare.peak_memory_usage', 5 * 1024 * 1024);
+        ->toHaveKey('flare.span_type', SpanType::Request);
+
+    if (PHP_VERSION_ID >= 80200) {
+        expect($span->attributes)->toHaveKey('flare.peak_memory_usage', 5 * 1024 * 1024);
+    }
 });
 
 it('does not unsample when url does not match ignored list', function () {

--- a/tests/Recorders/RequestRecorder/RequestRecorderTest.php
+++ b/tests/Recorders/RequestRecorder/RequestRecorderTest.php
@@ -2,6 +2,7 @@
 
 use Spatie\FlareClient\Enums\SpanType;
 use Spatie\FlareClient\FlareConfig;
+use Spatie\FlareClient\Memory\SystemMemory;
 use Spatie\FlareClient\Spans\Span;
 use Spatie\FlareClient\Tests\Shared\FakeMemory;
 use Symfony\Component\HttpFoundation\Request;
@@ -31,7 +32,7 @@ it('can trace requests', function () {
     expect($span->attributes)
         ->toHaveKey('flare.span_type', SpanType::Request);
 
-    if (PHP_VERSION_ID >= 80200) {
+    if (SystemMemory::phpVersionCanTrackMemory()) {
         expect($span->attributes)->toHaveKey('flare.peak_memory_usage', 5 * 1024 * 1024);
     }
 });

--- a/tests/Support/SymfonyTester.php
+++ b/tests/Support/SymfonyTester.php
@@ -4,6 +4,7 @@ use Spatie\FlareClient\Enums\FlareEntityType;
 use Spatie\FlareClient\Enums\SpanEventType;
 use Spatie\FlareClient\Enums\SpanType;
 use Spatie\FlareClient\FlareConfig;
+use Spatie\FlareClient\Memory\SystemMemory;
 use Spatie\FlareClient\Senders\DaemonSender;
 use Spatie\FlareClient\Senders\Exceptions\BadResponseCode;
 use Spatie\FlareClient\Senders\Support\Response;
@@ -65,7 +66,7 @@ it('can send a trace', function () {
         ->expectAttribute('process.command', 'flare:test')
         ->expectAttribute('process.exit_code', 0);
 
-    if (PHP_VERSION_ID >= 80200) {
+    if (SystemMemory::phpVersionCanTrackMemory()) {
         $commandSpan->expectHasAttribute('flare.peak_memory_usage');
     }
 

--- a/tests/Support/SymfonyTester.php
+++ b/tests/Support/SymfonyTester.php
@@ -63,8 +63,11 @@ it('can send a trace', function () {
         ->expectParentId($applicationSpan)
         ->expectType(SpanType::Command)
         ->expectAttribute('process.command', 'flare:test')
-        ->expectAttribute('process.exit_code', 0)
-        ->expectHasAttribute('flare.peak_memory_usage');
+        ->expectAttribute('process.exit_code', 0);
+
+    if (PHP_VERSION_ID >= 80200) {
+        $commandSpan->expectHasAttribute('flare.peak_memory_usage');
+    }
 
     $commandSpan
         ->expectSpanEventCount(1)

--- a/tests/TracerTest.php
+++ b/tests/TracerTest.php
@@ -9,6 +9,7 @@ use Spatie\FlareClient\Enums\EntryPointType;
 use Spatie\FlareClient\Enums\SpanStatusCode;
 use Spatie\FlareClient\Enums\SpanType;
 use Spatie\FlareClient\FlareConfig;
+use Spatie\FlareClient\Memory\SystemMemory;
 use Spatie\FlareClient\Sampling\NeverSampler;
 use Spatie\FlareClient\Sampling\SamplingRule;
 use Spatie\FlareClient\Spans\Span;
@@ -467,7 +468,7 @@ it('can include the peak memory usage when ending a span', function () {
         ->expectAttributes([
             'flare.peak_memory_usage' => 5 * 1024 * 1024,
         ]);
-})->skip(PHP_VERSION_ID < 80200, 'Peak memory usage cannot be tracked before PHP 8.2');
+})->skip(! SystemMemory::phpVersionCanTrackMemory(), 'Peak memory usage cannot be tracked before PHP 8.2');
 
 it('does not send the peak memory usage attribute before PHP 8.2', function () {
     $tracer = setupFlare(alwaysSampleTraces: true)->tracer;
@@ -480,7 +481,7 @@ it('does not send the peak memory usage attribute before PHP 8.2', function () {
     $span = FakeApi::lastTrace()->expectSpan(0);
 
     expect($span->attributes())->not->toHaveKey('flare.peak_memory_usage');
-})->skip(PHP_VERSION_ID >= 80200, 'Only relevant before PHP 8.2');
+})->skip(SystemMemory::phpVersionCanTrackMemory(), 'Only relevant before PHP 8.2');
 
 it('can temporarily pause a trace sampling', function () {
     $tracer = setupFlare(alwaysSampleTraces: true)->tracer;

--- a/tests/TracerTest.php
+++ b/tests/TracerTest.php
@@ -467,7 +467,20 @@ it('can include the peak memory usage when ending a span', function () {
         ->expectAttributes([
             'flare.peak_memory_usage' => 5 * 1024 * 1024,
         ]);
-});
+})->skip(PHP_VERSION_ID < 80200, 'Peak memory usage cannot be tracked before PHP 8.2');
+
+it('does not send the peak memory usage attribute before PHP 8.2', function () {
+    $tracer = setupFlare(alwaysSampleTraces: true)->tracer;
+
+    $tracer->startTrace();
+    $tracer->startSpan('Some span');
+    $tracer->endSpan(includeMemoryUsage: true);
+    $tracer->endTrace();
+
+    $span = FakeApi::lastTrace()->expectSpan(0);
+
+    expect($span->attributes())->not->toHaveKey('flare.peak_memory_usage');
+})->skip(PHP_VERSION_ID >= 80200, 'Only relevant before PHP 8.2');
 
 it('can temporarily pause a trace sampling', function () {
     $tracer = setupFlare(alwaysSampleTraces: true)->tracer;


### PR DESCRIPTION
Lowers the required PHP version from `^8.2` to `^8.1` and adds 8.1 to the CI test matrix. The only 8.2-specific runtime dependency was `memory_reset_peak_usage()`, used for per-span peak memory tracking, so on PHP 8.1 the reset becomes a no-op and the `flare.peak_memory_usage` span attribute is omitted rather than reporting an unscoped, misleading value. Tests are version-gated so both the 8.2+ (attribute present) and 8.1 (attribute absent) behaviors are covered. The `spatie/flare-daemon` constraint is bumped to `^0.3`, the first release supporting PHP 8.1.