### PR TITLE
Add expectAttributeIf test helper

### DIFF
--- a/shared/Concerns/ExpectAttributes.php
+++ b/shared/Concerns/ExpectAttributes.php
@@ -30,6 +30,15 @@ trait ExpectAttributes
         return $this;
     }
 
+    public function expectAttributeIf(bool $condition, string $key, mixed $value): self
+    {
+        if (! $condition) {
+            return $this;
+        }
+
+        return $this->expectAttribute($key, $value);
+    }
+
     public function expectHasAttribute(string $key): self
     {
         expect($this->attributes())->toHaveKey($key);


### PR DESCRIPTION
Adds an `expectAttributeIf` helper to the shared `ExpectAttributes` concern. It asserts an attribute only when a condition is true, otherwise it is a no-op and returns `$this` for chaining.

This keeps version conditional assertions readable in the suites that consume these shared helpers. For example, `spatie/laravel-flare` needs to assert `cache.store` only on Laravel 11+ (cache events did not expose the store name on Laravel 10):

```php
$event
    ->expectAttribute('cache.key', 'foo')
    ->expectAttributeIf($hasStoreName, 'cache.store', 'database');
```

Purely additive to the test helpers.