### PR TITLE
Trim large span attributes at record time to bound trace memory

### DIFF
--- a/src/Concerns/Recorders/LargeAttributesTrimmingRecorder.php
+++ b/src/Concerns/Recorders/LargeAttributesTrimmingRecorder.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Spatie\FlareClient\Concerns\Recorders;
+
+use Spatie\FlareClient\Spans\Span;
+use Spatie\FlareClient\Spans\SpanEvent;
+use Spatie\FlareClient\Support\AttributeSizeLimiter;
+
+trait LargeAttributesTrimmingRecorder
+{
+    protected function shouldTrimAttributes(): bool
+    {
+        return false;
+    }
+
+    protected function trimAttributes(Span|SpanEvent $entry): void
+    {
+        if (! $this->shouldTrimAttributes()) {
+            return;
+        }
+
+        $budgetInKb = $this->tracer->limits['max_attribute_size_in_kb'];
+
+        if ($budgetInKb <= 0) {
+            return;
+        }
+
+        [$entry->attributes, $dropped] = (new AttributeSizeLimiter())->limit($entry->attributes, $budgetInKb * 1024);
+
+        $entry->droppedAttributesCount += $dropped;
+    }
+}

--- a/src/Concerns/Recorders/LargeAttributesTrimmingRecorder.php
+++ b/src/Concerns/Recorders/LargeAttributesTrimmingRecorder.php
@@ -4,7 +4,7 @@ namespace Spatie\FlareClient\Concerns\Recorders;
 
 use Spatie\FlareClient\Spans\Span;
 use Spatie\FlareClient\Spans\SpanEvent;
-use Spatie\FlareClient\Support\AttributeSizeLimiter;
+use Spatie\FlareClient\Support\LargeAttributesTrimmer;
 
 trait LargeAttributesTrimmingRecorder
 {
@@ -19,14 +19,6 @@ trait LargeAttributesTrimmingRecorder
             return;
         }
 
-        $budgetInKb = $this->tracer->limits['max_attribute_size_in_kb'];
-
-        if ($budgetInKb <= 0) {
-            return;
-        }
-
-        [$entry->attributes, $dropped] = (new AttributeSizeLimiter())->limit($entry->attributes, $budgetInKb * 1024);
-
-        $entry->droppedAttributesCount += $dropped;
+        (new LargeAttributesTrimmer())->trim($entry, $this->tracer->limits['max_attribute_size_in_kb']);
     }
 }

--- a/src/Concerns/Recorders/LargeAttributesTrimmingRecorder.php
+++ b/src/Concerns/Recorders/LargeAttributesTrimmingRecorder.php
@@ -4,7 +4,6 @@ namespace Spatie\FlareClient\Concerns\Recorders;
 
 use Spatie\FlareClient\Spans\Span;
 use Spatie\FlareClient\Spans\SpanEvent;
-use Spatie\FlareClient\Support\LargeAttributesTrimmer;
 
 trait LargeAttributesTrimmingRecorder
 {
@@ -19,6 +18,6 @@ trait LargeAttributesTrimmingRecorder
             return;
         }
 
-        (new LargeAttributesTrimmer())->trim($entry, $this->tracer->limits['max_attribute_size_in_kb']);
+        $this->tracer->largeAttributesTrimmer->trim($entry, $this->tracer->limits['max_attribute_size_in_kb']);
     }
 }

--- a/src/FlareConfig.php
+++ b/src/FlareConfig.php
@@ -58,7 +58,7 @@ class FlareConfig
      * @param null|Closure(ReportFactory): bool $filterReportsCallable
      * @param array<string, array{type: FlareCollectType, ignored: ?bool, options: array}> $collects
      * @param class-string<Sender> $sender
-     * @param array{max_spans: int, max_attributes_per_span: int, max_span_events_per_span:int, max_attributes_per_span_event:int}|null $traceLimits
+     * @param array{max_spans: int, max_attributes_per_span: int, max_span_events_per_span:int, max_attributes_per_span_event:int, max_attribute_size_in_kb?:int}|null $traceLimits
      * @param Closure(Scope):void|null $configureScopeCallable
      * @param Closure(Resource):void|null $configureResourceCallable
      * @param Closure(Span):(void|Span)|null $configureSpansCallable
@@ -656,6 +656,7 @@ class FlareConfig
         int $maxAttributesPerSpan = Tracer::DEFAULT_MAX_ATTRIBUTES_PER_SPAN_LIMIT,
         int $maxSpanEventsPerSpan = Tracer::DEFAULT_MAX_SPAN_EVENTS_PER_SPAN_LIMIT,
         int $maxAttributesPerSpanEvent = Tracer::DEFAULT_MAX_ATTRIBUTES_PER_SPAN_EVENT_LIMIT,
+        int $maxAttributeSizeInKb = Tracer::DEFAULT_MAX_ATTRIBUTE_SIZE_IN_KB,
     ): static {
         $this->trace = $trace;
 
@@ -664,6 +665,7 @@ class FlareConfig
             'max_attributes_per_span' => $maxAttributesPerSpan,
             'max_span_events_per_span' => $maxSpanEventsPerSpan,
             'max_attributes_per_span_event' => $maxAttributesPerSpanEvent,
+            'max_attribute_size_in_kb' => $maxAttributeSizeInKb,
         ];
 
         return $this;
@@ -799,12 +801,14 @@ class FlareConfig
         int $maxAttributesPerSpan = Tracer::DEFAULT_MAX_ATTRIBUTES_PER_SPAN_LIMIT,
         int $maxSpanEventsPerSpan = Tracer::DEFAULT_MAX_SPAN_EVENTS_PER_SPAN_LIMIT,
         int $maxAttributesPerSpanEvent = Tracer::DEFAULT_MAX_ATTRIBUTES_PER_SPAN_EVENT_LIMIT,
+        int $maxAttributeSizeInKb = Tracer::DEFAULT_MAX_ATTRIBUTE_SIZE_IN_KB,
     ): static {
         $this->traceLimits = [
             'max_spans' => $maxSpans,
             'max_attributes_per_span' => $maxAttributesPerSpan,
             'max_span_events_per_span' => $maxSpanEventsPerSpan,
             'max_attributes_per_span_event' => $maxAttributesPerSpanEvent,
+            'max_attribute_size_in_kb' => $maxAttributeSizeInKb,
         ];
 
         return $this;

--- a/src/Recorders/GlowRecorder/GlowRecorder.php
+++ b/src/Recorders/GlowRecorder/GlowRecorder.php
@@ -15,6 +15,11 @@ class GlowRecorder extends SpanEventsRecorder
         return RecorderType::Glow;
     }
 
+    protected function shouldTrimAttributes(): bool
+    {
+        return true;
+    }
+
     public function record(
         string $name,
         Level $level = Level::Info,

--- a/src/Recorders/QueryRecorder/QueryRecorder.php
+++ b/src/Recorders/QueryRecorder/QueryRecorder.php
@@ -28,6 +28,11 @@ class QueryRecorder extends SpansRecorder
         $this->includeBindings = $config['include_bindings'] ?? true;
     }
 
+    protected function shouldTrimAttributes(): bool
+    {
+        return true;
+    }
+
     public function record(
         string $sql,
         int $duration,

--- a/src/Recorders/SpanEventsRecorder.php
+++ b/src/Recorders/SpanEventsRecorder.php
@@ -6,6 +6,7 @@ use Closure;
 use InvalidArgumentException;
 use Spatie\FlareClient\Concerns\Recorders\BacktracingRecorder;
 use Spatie\FlareClient\Concerns\Recorders\ErrorsRecorder;
+use Spatie\FlareClient\Concerns\Recorders\LargeAttributesTrimmingRecorder;
 use Spatie\FlareClient\Concerns\Recorders\TracingRecorder;
 use Spatie\FlareClient\Contracts\Recorders\SpanEventsRecorder as SpanEventsRecorderContract;
 use Spatie\FlareClient\Spans\SpanEvent;
@@ -14,6 +15,8 @@ use Spatie\FlareClient\Tracer;
 
 abstract class SpanEventsRecorder extends Recorder implements SpanEventsRecorderContract
 {
+    use LargeAttributesTrimmingRecorder;
+
     /** @use BacktracingRecorder<SpanEvent> */
     use BacktracingRecorder;
 
@@ -114,6 +117,8 @@ abstract class SpanEventsRecorder extends Recorder implements SpanEventsRecorder
         if ($spanEventCallback) {
             $spanEventCallback($spanEvent);
         }
+
+        $this->trimAttributes($spanEvent);
 
         if ($shouldReport) {
             $this->addEntryToReport($spanEvent);

--- a/src/Recorders/SpansRecorder.php
+++ b/src/Recorders/SpansRecorder.php
@@ -6,6 +6,7 @@ use Closure;
 use InvalidArgumentException;
 use Spatie\FlareClient\Concerns\Recorders\BacktracingRecorder;
 use Spatie\FlareClient\Concerns\Recorders\ErrorsRecorder;
+use Spatie\FlareClient\Concerns\Recorders\LargeAttributesTrimmingRecorder;
 use Spatie\FlareClient\Concerns\Recorders\TracingRecorder;
 use Spatie\FlareClient\Contracts\Recorders\SpansRecorder as SpansRecorderContract;
 use Spatie\FlareClient\Spans\Span;
@@ -15,6 +16,8 @@ use Spatie\FlareClient\Tracer;
 
 abstract class SpansRecorder extends Recorder implements SpansRecorderContract
 {
+    use LargeAttributesTrimmingRecorder;
+
     /** @use BacktracingRecorder<Span> */
     use BacktracingRecorder;
 
@@ -167,6 +170,8 @@ abstract class SpansRecorder extends Recorder implements SpansRecorderContract
         if (count($additionalAttributes) > 0) {
             $span->addAttributes($additionalAttributes);
         }
+
+        $this->trimAttributes($span);
 
         if ($shouldTrace) {
             $this->tracer->endSpan($span, includeMemoryUsage: $includeMemoryUsage);

--- a/src/Support/AttributeSizeLimiter.php
+++ b/src/Support/AttributeSizeLimiter.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace Spatie\FlareClient\Support;
+
+class AttributeSizeLimiter
+{
+    protected const LEAF_BYTES = 4;
+
+    /**
+     * @param array<string, mixed> $attributes
+     *
+     * @return array{array<string, mixed>, int}
+     */
+    public function limit(array $attributes, int $budget): array
+    {
+        $dropped = 0;
+
+        foreach ($attributes as $key => $value) {
+            if (! is_string($value) && ! is_array($value)) {
+                continue;
+            }
+
+            $remaining = $budget;
+
+            if ($this->walk($value, $remaining)) {
+                unset($attributes[$key]);
+
+                $dropped++;
+            }
+        }
+
+        return [$attributes, $dropped];
+    }
+
+    protected function walk(mixed $value, int &$remaining): bool
+    {
+        if (is_string($value)) {
+            $remaining -= strlen($value);
+
+            return $remaining < 0;
+        }
+
+        if (! is_array($value)) {
+            $remaining -= self::LEAF_BYTES;
+
+            return $remaining < 0;
+        }
+
+        foreach ($value as $key => $item) {
+            $remaining -= is_string($key) ? strlen($key) : self::LEAF_BYTES;
+
+            if ($remaining < 0) {
+                return true;
+            }
+
+            if ($this->walk($item, $remaining)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}

--- a/src/Support/LargeAttributesTrimmer.php
+++ b/src/Support/LargeAttributesTrimmer.php
@@ -2,16 +2,30 @@
 
 namespace Spatie\FlareClient\Support;
 
-class AttributeSizeLimiter
+use Spatie\FlareClient\Spans\Span;
+use Spatie\FlareClient\Spans\SpanEvent;
+
+class LargeAttributesTrimmer
 {
     protected const LEAF_BYTES = 4;
+
+    public function trim(Span|SpanEvent $entry, int $budgetInKb): void
+    {
+        if ($budgetInKb <= 0) {
+            return;
+        }
+
+        [$entry->attributes, $dropped] = $this->limit($entry->attributes, $budgetInKb * 1024);
+
+        $entry->droppedAttributesCount += $dropped;
+    }
 
     /**
      * @param array<string, mixed> $attributes
      *
      * @return array{array<string, mixed>, int}
      */
-    public function limit(array $attributes, int $budget): array
+    protected function limit(array $attributes, int $budget): array
     {
         $dropped = 0;
 

--- a/src/Tracer.php
+++ b/src/Tracer.php
@@ -28,13 +28,14 @@ class Tracer
     public const DEFAULT_MAX_ATTRIBUTES_PER_SPAN_LIMIT = 128;
     public const DEFAULT_MAX_SPAN_EVENTS_PER_SPAN_LIMIT = 128;
     public const DEFAULT_MAX_ATTRIBUTES_PER_SPAN_EVENT_LIMIT = 128;
+    public const DEFAULT_MAX_ATTRIBUTE_SIZE_IN_KB = 32; // string/array attributes larger than this are dropped
 
     public const DEFAULT_COLLECT_ERRORS_WITH_TRACES = true;
 
     /** @var array<Span> */
     protected array $spans = [];
 
-    /** @var array @param array{max_spans: int, max_attributes_per_span: int, max_span_events_per_span: int, max_attributes_per_span_event: int}|null */
+    /** @var array @param array{max_spans: int, max_attributes_per_span: int, max_span_events_per_span: int, max_attributes_per_span_event: int, max_attribute_size_in_kb?: int}|null */
     public readonly array $limits;
 
     protected ?string $currentTraceId = null;
@@ -44,7 +45,7 @@ class Tracer
     protected bool $currentSpanIdAvailable = true;
 
     /**
-     * @param array{max_spans: int, max_attributes_per_span: int, max_span_events_per_span: int, max_attributes_per_span_event: int}|null $limits
+     * @param array{max_spans: int, max_attributes_per_span: int, max_span_events_per_span: int, max_attributes_per_span_event: int, max_attribute_size_in_kb?: int}|null $limits
      * @param Closure(Span):(void|Span)|null $configureSpansCallable
      * @param Closure(SpanEvent):(void|SpanEvent|null)|null $configureSpanEventsCallable
      * @param Closure(Span):(bool)|null $gracefulSpanEnderClosure ,
@@ -70,6 +71,7 @@ class Tracer
             'max_attributes_per_span' => $limits['max_attributes_per_span'] ?? self::DEFAULT_MAX_ATTRIBUTES_PER_SPAN_LIMIT,
             'max_span_events_per_span' => $limits['max_span_events_per_span'] ?? self::DEFAULT_MAX_SPAN_EVENTS_PER_SPAN_LIMIT,
             'max_attributes_per_span_event' => $limits['max_attributes_per_span_event'] ?? self::DEFAULT_MAX_ATTRIBUTES_PER_SPAN_EVENT_LIMIT,
+            'max_attribute_size_in_kb' => $limits['max_attribute_size_in_kb'] ?? self::DEFAULT_MAX_ATTRIBUTE_SIZE_IN_KB,
         ];
     }
 

--- a/src/Tracer.php
+++ b/src/Tracer.php
@@ -18,6 +18,7 @@ use Spatie\FlareClient\Sampling\Sampler;
 use Spatie\FlareClient\Spans\Span;
 use Spatie\FlareClient\Spans\SpanEvent;
 use Spatie\FlareClient\Support\Ids;
+use Spatie\FlareClient\Support\LargeAttributesTrimmer;
 use Spatie\FlareClient\Support\Recorders;
 use Spatie\FlareClient\Time\Time;
 use Throwable;
@@ -490,6 +491,8 @@ class Tracer
             }
 
             if ($this->gracefulSpanEnderClosure === null || $force || ($this->gracefulSpanEnderClosure)($currentSpan)) {
+                (new LargeAttributesTrimmer())->trim($currentSpan, $this->limits['max_attribute_size_in_kb']);
+
                 $this->endSpan($currentSpan);
             }
 

--- a/src/Tracer.php
+++ b/src/Tracer.php
@@ -66,6 +66,7 @@ class Tracer
         protected bool $paused = false,
         public readonly bool $disabled = false,
         protected Closure|null $gracefulSpanEnderClosure = null,
+        public readonly LargeAttributesTrimmer $largeAttributesTrimmer = new LargeAttributesTrimmer(),
     ) {
         $this->limits = [
             'max_spans' => $limits['max_spans'] ?? self::DEFAULT_MAX_SPANS_LIMIT,
@@ -491,7 +492,7 @@ class Tracer
             }
 
             if ($this->gracefulSpanEnderClosure === null || $force || ($this->gracefulSpanEnderClosure)($currentSpan)) {
-                (new LargeAttributesTrimmer())->trim($currentSpan, $this->limits['max_attribute_size_in_kb']);
+                $this->largeAttributesTrimmer->trim($currentSpan, $this->limits['max_attribute_size_in_kb']);
 
                 $this->endSpan($currentSpan);
             }

--- a/tests/Recorders/SpanEventsRecorderTest.php
+++ b/tests/Recorders/SpanEventsRecorderTest.php
@@ -184,7 +184,7 @@ it('is possible to disable the recorder for tracing', function () {
 it('a closure passed span event will not be executed when not tracing or reporting', function () {
     class TestConcreteSpanEventsRecorderExecution extends ConcreteSpanEventsRecorder
     {
-        public function record(string $message): ?SpanEvent
+        public function record(string $message, array $attributes = []): ?SpanEvent
         {
             $this->spanEvent(fn () => throw new Exception('Closure executed'));
         }
@@ -288,4 +288,30 @@ it('will not find origins when only reporting', function () {
         'code.lineno',
         'code.function',
     ]);
+});
+
+it('strips string and array attributes larger than the max attribute size', function () {
+    $flare = setupFlare(function (FlareConfig $config) {
+        $config->trace(maxAttributeSizeInKb: 1);
+    });
+
+    $recorder = new ConcreteSpanEventsRecorder($flare->tracer, $flare->backTracer, config: [
+        'with_errors' => true,
+    ]);
+
+    $recorder->record('Hello World', [
+        'big_string' => str_repeat('a', 2000),
+        'big_array' => ['nested' => str_repeat('b', 2000)],
+        'small_string' => 'kept',
+        'number' => 999999999,
+    ]);
+
+    $spanEvent = $recorder->getSpanEvents()[0];
+
+    expect($spanEvent->attributes)
+        ->not()->toHaveKey('big_string')
+        ->not()->toHaveKey('big_array')
+        ->toHaveKey('small_string', 'kept')
+        ->toHaveKey('number', 999999999);
+    expect($spanEvent->droppedAttributesCount)->toBe(2);
 });

--- a/tests/Recorders/SpansRecorderTest.php
+++ b/tests/Recorders/SpansRecorderTest.php
@@ -424,3 +424,30 @@ it('strips string and array attributes larger than the max attribute size', func
         ->toHaveKey('number', 999999999);
     expect($span->droppedAttributesCount)->toBe(2);
 });
+
+it('strips large attributes from spans gracefully ended by the tracer', function () {
+    $flare = setupFlare(function (FlareConfig $config) {
+        $config->alwaysSampleTraces()->trace(maxAttributeSizeInKb: 1);
+    });
+
+    $recorder = new ConcreteSpansRecorder($flare->tracer, $flare->backTracer, config: [
+        'with_traces' => true,
+    ]);
+
+    $flare->tracer->startTrace();
+
+    $recorder->pushSpan('Span', [
+        'big_string' => str_repeat('a', 2000),
+        'small_string' => 'kept',
+    ]);
+
+    $flare->tracer->gracefullyEndSpans(force: true);
+
+    $span = array_values($flare->tracer->currentTrace())[0];
+
+    expect($span->end)->not()->toBeNull();
+    expect($span->attributes)
+        ->not()->toHaveKey('big_string')
+        ->toHaveKey('small_string', 'kept');
+    expect($span->droppedAttributesCount)->toBe(1);
+});

--- a/tests/Recorders/SpansRecorderTest.php
+++ b/tests/Recorders/SpansRecorderTest.php
@@ -396,3 +396,31 @@ it('will correctly nest spans', function () {
 
     $recorder->popSpan();
 });
+
+it('strips string and array attributes larger than the max attribute size', function () {
+    $flare = setupFlare(function (FlareConfig $config) {
+        $config->alwaysSampleTraces()->trace(maxAttributeSizeInKb: 1);
+    });
+
+    $recorder = new ConcreteSpansRecorder($flare->tracer, $flare->backTracer, config: [
+        'with_traces' => true,
+    ]);
+
+    $flare->tracer->startTrace();
+
+    $recorder->record('Span', 100, [
+        'big_string' => str_repeat('a', 2000),
+        'big_array' => ['nested' => str_repeat('b', 2000)],
+        'small_string' => 'kept',
+        'number' => 999999999,
+    ]);
+
+    $span = array_values($flare->tracer->currentTrace())[0];
+
+    expect($span->attributes)
+        ->not()->toHaveKey('big_string')
+        ->not()->toHaveKey('big_array')
+        ->toHaveKey('small_string', 'kept')
+        ->toHaveKey('number', 999999999);
+    expect($span->droppedAttributesCount)->toBe(2);
+});

--- a/tests/Support/LargeAttributesTrimmerTest.php
+++ b/tests/Support/LargeAttributesTrimmerTest.php
@@ -1,0 +1,35 @@
+<?php
+
+use Spatie\FlareClient\Spans\SpanEvent;
+use Spatie\FlareClient\Support\LargeAttributesTrimmer;
+
+it('drops string and array attributes exceeding the budget', function () {
+    $spanEvent = new SpanEvent('Event', 0, [
+        'big_string' => str_repeat('a', 1025),
+        'exact_string' => str_repeat('b', 1024),
+        'big_nested_array' => ['nested' => str_repeat('c', 2000)],
+        'big_array_by_item_count' => array_fill(0, 300, 1),
+        'number' => PHP_INT_MAX,
+        'small_string' => 'kept',
+    ]);
+
+    (new LargeAttributesTrimmer())->trim($spanEvent, 1);
+
+    expect($spanEvent->attributes)->toBe([
+        'exact_string' => str_repeat('b', 1024),
+        'number' => PHP_INT_MAX,
+        'small_string' => 'kept',
+    ]);
+    expect($spanEvent->droppedAttributesCount)->toBe(3);
+});
+
+it('does not trim when the budget is disabled', function () {
+    $spanEvent = new SpanEvent('Event', 0, [
+        'big_string' => str_repeat('a', 5000),
+    ]);
+
+    (new LargeAttributesTrimmer())->trim($spanEvent, 0);
+
+    expect($spanEvent->attributes)->toHaveKey('big_string');
+    expect($spanEvent->droppedAttributesCount)->toBe(0);
+});

--- a/tests/TestClasses/ConcreteSpanEventsRecorder.php
+++ b/tests/TestClasses/ConcreteSpanEventsRecorder.php
@@ -13,13 +13,19 @@ class ConcreteSpanEventsRecorder extends SpanEventsRecorder
         return 'spans';
     }
 
-    public function record(string $message): ?SpanEvent
+    public function record(string $message, array $attributes = []): ?SpanEvent
     {
         return $this->spanEvent(
             name: "Span Event - {$message}",
             attributes: fn () => [
                 'message' => $message,
+                ...$attributes,
             ],
         );
+    }
+
+    protected function shouldTrimAttributes(): bool
+    {
+        return true;
     }
 }

--- a/tests/TestClasses/ConcreteSpansRecorder.php
+++ b/tests/TestClasses/ConcreteSpansRecorder.php
@@ -26,11 +26,18 @@ class ConcreteSpansRecorder extends SpansRecorder
     public function record(
         string $name,
         int $duration,
+        array $attributes = [],
     ): ?Span {
         return $this->span(
             $name,
+            attributes: $attributes,
             duration: $duration,
         );
+    }
+
+    protected function shouldTrimAttributes(): bool
+    {
+        return true;
     }
 
     public function pause(): void

--- a/tests/TestClasses/ConcreteSpansRecorder.php
+++ b/tests/TestClasses/ConcreteSpansRecorder.php
@@ -13,9 +13,9 @@ class ConcreteSpansRecorder extends SpansRecorder
         return 'spans';
     }
 
-    public function pushSpan(string $name): ?Span
+    public function pushSpan(string $name, array $attributes = []): ?Span
     {
-        return $this->startSpan(name: $name);
+        return $this->startSpan(name: $name, attributes: $attributes);
     }
 
     public function popSpan(): ?Span


### PR DESCRIPTION
Query-heavy commands (e.g. thousands of bulk `upsert()`s) could accumulate multi-MB query spans in memory until the process hit `memory_limit`, since spans are retained for the whole trace and the existing `ReportTrimmer` only runs at send time. This adds a `LargeAttributesTrimmingRecorder` trait that, at record time, drops any string or array attribute exceeding a configurable byte budget (`max_attribute_size_in_kb`, default 32KB) using an allocation-free early-exit `AttributeSizeLimiter`, incrementing the OpenTelemetry `droppedAttributesCount`. Trimming is opt-in per recorder via `shouldTrimAttributes()` (off by default) and is enabled for `QueryRecorder` and `GlowRecorder`, covering both spans and span events. Scalars, bools, floats and enums are never touched, and `0` disables trimming. Downstream note: `laravel-flare` mirrors this trace-limits config and will need the same `max_attribute_size_in_kb` key added.