### PR TITLE
Add ability to skip cache keys in the CacheRecorder

### DIFF
--- a/src/FlareConfig.php
+++ b/src/FlareConfig.php
@@ -305,6 +305,7 @@ class FlareConfig
         bool $withErrors = CacheRecorder::DEFAULT_WITH_ERRORS,
         ?int $maxItemsWithErrors = CacheRecorder::DEFAULT_MAX_ITEMS_WITH_ERRORS,
         array $operations = CacheRecorder::DEFAULT_OPERATIONS,
+        array $ignoredKeys = [],
         array $extra = [],
     ): static {
         return $this->addCollect(CollectType::Cache, [
@@ -312,6 +313,7 @@ class FlareConfig
             'with_errors' => $withErrors,
             'max_items_with_errors' => $maxItemsWithErrors,
             'operations' => $operations,
+            'ignored_keys' => $ignoredKeys,
             ...$extra,
         ]);
     }

--- a/src/FlareConfig.php
+++ b/src/FlareConfig.php
@@ -300,6 +300,9 @@ class FlareConfig
         return $this->ignoreCollect(CollectType::GitInfo);
     }
 
+    /**
+     * @param array<int, string> $ignoredKeys
+     */
     public function collectCacheEvents(
         bool $withTraces = CacheRecorder::DEFAULT_WITH_TRACES,
         bool $withErrors = CacheRecorder::DEFAULT_WITH_ERRORS,

--- a/src/Recorders/CacheRecorder/CacheRecorder.php
+++ b/src/Recorders/CacheRecorder/CacheRecorder.php
@@ -8,6 +8,7 @@ use Spatie\FlareClient\Enums\RecorderType;
 use Spatie\FlareClient\Enums\SpanEventType;
 use Spatie\FlareClient\Recorders\SpanEventsRecorder;
 use Spatie\FlareClient\Spans\SpanEvent;
+use Spatie\FlareClient\Support\PatternMatcher;
 
 class CacheRecorder extends SpanEventsRecorder
 {
@@ -15,6 +16,9 @@ class CacheRecorder extends SpanEventsRecorder
      * @var array<CacheOperation|string>
      */
     protected array $operations = [];
+
+    /** @var array<int, string> */
+    protected array $ignoredKeys = [];
 
     public const DEFAULT_OPERATIONS = [CacheOperation::Get, CacheOperation::Set, CacheOperation::Forget];
 
@@ -29,6 +33,8 @@ class CacheRecorder extends SpanEventsRecorder
             fn (string|CacheOperation $spanEventType) => is_string($spanEventType) ? CacheOperation::tryFrom($spanEventType) : $spanEventType,
             $config['operations'] ?? [],
         ));
+
+        $this->ignoredKeys = $config['ignored_keys'] ?? [];
     }
 
     public function recordHit(string $key, ?string $store): ?SpanEvent
@@ -62,6 +68,10 @@ class CacheRecorder extends SpanEventsRecorder
             return null;
         }
 
+        if ($this->shouldIgnoreKey($key)) {
+            return null;
+        }
+
         $name = match ([$operation, $result]) {
             [CacheOperation::Get, CacheResult::Hit] => 'hit',
             [CacheOperation::Get, CacheResult::Miss] => 'miss',
@@ -81,5 +91,16 @@ class CacheRecorder extends SpanEventsRecorder
                 ...$attributes,
             ]
         );
+    }
+
+    protected function shouldIgnoreKey(string $key): bool
+    {
+        return PatternMatcher::matchesAny($key, [...$this->ignoredKeys, ...$this->defaultIgnoredKeys()]);
+    }
+
+    /** @return array<int, string> */
+    protected function defaultIgnoredKeys(): array
+    {
+        return [];
     }
 }

--- a/src/Support/CollectsResolver.php
+++ b/src/Support/CollectsResolver.php
@@ -208,6 +208,7 @@ class CollectsResolver
             'with_errors',
             'max_items_with_errors',
             'operations',
+            'ignored_keys',
         ]));
     }
 

--- a/tests/Recorders/CacheRecorder/CacheRecorderTest.php
+++ b/tests/Recorders/CacheRecorder/CacheRecorderTest.php
@@ -109,3 +109,27 @@ it('can limit the kinds of events being recorder', function () {
 
     expect($events)->toBe([$keyWrite]);
 });
+
+it('can ignore cache keys', function () {
+    $flare = setupFlare();
+
+    $recorder = new CacheRecorder(
+        tracer: $flare->tracer,
+        backTracer: $flare->backTracer,
+        config: [
+            'with_traces' => true,
+            'with_errors' => true,
+            'max_items_with_errors' => 10,
+            'operations' => [CacheOperation::Get, CacheOperation::Set, CacheOperation::Forget],
+            'ignored_keys' => ['framework:*', 'exact-key'],
+        ]
+    );
+
+    $recorder->boot();
+
+    $recorder->recordHit('framework:schedule', 'store');
+    $recorder->recordHit('exact-key', 'store');
+    $recorded = $recorder->recordHit('some-key', 'store');
+
+    expect($recorder->getSpanEvents())->toBe([$recorded]);
+});


### PR DESCRIPTION
The `CacheRecorder` can now skip cache keys, following the same pattern as the ignore options on the request, queue, job, command and routing recorders.

Keys come from two sources that both always apply: an `ignored_keys` option users set through `FlareConfig::collectCacheEvents()`, and a `defaultIgnoredKeys()` method that returns an empty array here and is meant to be filled in by framework adapters like `spatie/laravel-flare`. Matching runs through `PatternMatcher::matchesAny()`, so patterns use `*` globs. `shouldIgnoreKey()` is protected so adapters can override it to carve out exceptions (Laravel needs this because `Cache::flexible()` writes keys under an `illuminate:` prefix that embed a user defined key).