### PR TITLE
Add regex matching to PatternMatcher

### DIFF
--- a/src/Support/PatternMatcher.php
+++ b/src/Support/PatternMatcher.php
@@ -22,4 +22,21 @@ class PatternMatcher
 
         return false;
     }
+
+    public static function regex(string $value, string $pattern): bool
+    {
+        return @preg_match($pattern, $value) === 1;
+    }
+
+    /** @param array<int, string> $patterns */
+    public static function regexAny(string $value, array $patterns): bool
+    {
+        foreach ($patterns as $pattern) {
+            if (self::regex($value, $pattern)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
 }

--- a/tests/Support/PatternMatcherTest.php
+++ b/tests/Support/PatternMatcherTest.php
@@ -47,3 +47,25 @@ it('matches any when at least one pattern matches', function () {
 it('does not match any when no pattern matches', function () {
     expect(PatternMatcher::matchesAny('serve', ['migrate', 'make:*', 'queue:work']))->toBeFalse();
 });
+
+it('matches a regex pattern', function () {
+    expect(PatternMatcher::regex('telescope:prune', '/^telescope:/'))->toBeTrue();
+    expect(PatternMatcher::regex('app:telescope:prune', '/^telescope:/'))->toBeFalse();
+    expect(PatternMatcher::regex('framework/schedule', '/^framework\/schedule/'))->toBeTrue();
+    expect(PatternMatcher::regex('illuminate:cache:key', '/^illuminate:(?!cache:flexible:created:)/'))->toBeTrue();
+    expect(PatternMatcher::regex('illuminate:cache:flexible:created:key', '/^illuminate:(?!cache:flexible:created:)/'))->toBeFalse();
+});
+
+it('never matches an invalid regex pattern', function () {
+    set_error_handler(fn () => true);
+
+    expect(PatternMatcher::regex('anything', '/^unterminated('))->toBeFalse();
+
+    restore_error_handler();
+});
+
+it('matches any regex pattern', function () {
+    expect(PatternMatcher::regexAny('telescope:prune', ['/^queue:/', '/^telescope:/']))->toBeTrue();
+    expect(PatternMatcher::regexAny('serve', ['/^queue:/', '/^telescope:/']))->toBeFalse();
+    expect(PatternMatcher::regexAny('anything', []))->toBeFalse();
+});

--- a/tests/Support/PatternMatcherTest.php
+++ b/tests/Support/PatternMatcherTest.php
@@ -59,9 +59,11 @@ it('matches a regex pattern', function () {
 it('never matches an invalid regex pattern', function () {
     set_error_handler(fn () => true);
 
-    expect(PatternMatcher::regex('anything', '/^unterminated('))->toBeFalse();
-
-    restore_error_handler();
+    try {
+        expect(PatternMatcher::regex('anything', '/^unterminated('))->toBeFalse();
+    } finally {
+        restore_error_handler();
+    }
 });
 
 it('matches any regex pattern', function () {


### PR DESCRIPTION
Adds `PatternMatcher::regex()` and `PatternMatcher::regexAny()` next to the existing glob-style `matches()` and `matchesAny()`. Patterns carry their own delimiters, for example `/^telescope:/`, so they are passed to `preg_match()` untouched and can contain a slash or a lookahead. An invalid pattern never matches and its warning is suppressed, since these patterns are written by the package rather than by users. This is groundwork only: no call sites change and the glob behaviour stays exactly as it was.