### PR TITLE
Match CacheRecorder ignored keys with regexes

### DIFF
--- a/src/Recorders/CacheRecorder/CacheRecorder.php
+++ b/src/Recorders/CacheRecorder/CacheRecorder.php
@@ -95,10 +95,10 @@ class CacheRecorder extends SpanEventsRecorder
 
     protected function shouldIgnoreKey(string $key): bool
     {
-        return PatternMatcher::matchesAny($key, [...$this->ignoredKeys, ...$this->defaultIgnoredKeys()]);
+        return PatternMatcher::regexAny($key, [...$this->ignoredKeys, ...$this->defaultIgnoredKeys()]);
     }
 
-    /** @return array<int, string> */
+    /** @return array<int, string> Regexes, just like the user configured ignored keys */
     protected function defaultIgnoredKeys(): array
     {
         return [];

--- a/tests/Recorders/CacheRecorder/CacheRecorderTest.php
+++ b/tests/Recorders/CacheRecorder/CacheRecorderTest.php
@@ -121,7 +121,7 @@ it('can ignore cache keys', function () {
             'with_errors' => true,
             'max_items_with_errors' => 10,
             'operations' => [CacheOperation::Get, CacheOperation::Set, CacheOperation::Forget],
-            'ignored_keys' => ['framework:*', 'exact-key'],
+            'ignored_keys' => ['/^framework:/', '/^exact-key$/'],
         ]
     );
 


### PR DESCRIPTION
`CacheRecorder::shouldIgnoreKey()` now runs both the user configured `ignored_keys` and the `defaultIgnoredKeys()` hook through `PatternMatcher::regexAny()` instead of the glob matcher. Framework adapters need the extra power: `spatie/laravel-flare` wants to ignore `illuminate:*` while keeping `illuminate:cache:flexible:created:{user key}`, which is a real user cache key written under a framework prefix, and that needs a lookahead.

This is a breaking change for anyone passing globs to `FlareConfig::collectCacheEvents(ignoredKeys: ...)`. `PatternMatcher::regex()` suppresses the invalid pattern warning and returns false, so an old glob like `framework:*` silently stops ignoring anything and those cache events start getting recorded again. Other recorders (`RequestRecorder`, `RoutingRecorder`, `QueueRecorder`, `JobRecorder`, `CommandRecorder`) keep glob semantics for now.