### PR TITLE
Always end the trace when a subtask ends

### DIFF
--- a/src/Support/Lifecycle.php
+++ b/src/Support/Lifecycle.php
@@ -257,9 +257,7 @@ class Lifecycle
 
         $this->stage = LifecycleStage::Idle;
 
-        if ($this->tracer->sampling === true) {
-            $this->tracer->endTrace();
-        }
+        $this->tracer->endTrace();
 
         $this->entryPointResolver->clear();
 

--- a/src/Tracer.php
+++ b/src/Tracer.php
@@ -128,6 +128,7 @@ class Tracer
             $this->sampler->reset();
         }
 
+        $this->paused = false;
         $this->currentTraceId = null;
         $this->currentSpanId = null;
         $this->currentSpanIdAvailable = true;

--- a/tests/Support/LifecylceTest.php
+++ b/tests/Support/LifecylceTest.php
@@ -401,24 +401,3 @@ it('resets trace state after an unsampled subtask so the next subtask can sample
 
     $flare->lifecycle->endSubtask();
 });
-
-it('asks the sampler again for each subtask without a traceparent', function () {
-    FakeSampler::setRandoms(0.9, 0.1);
-
-    $flare = setupFlare(
-        fn (FlareConfig $config) => $config->sampler(FakeSampler::class, ['rate' => 0.5]),
-        isUsingSubtasks: true
-    );
-
-    $flare->lifecycle->startSubtask();
-
-    expect($flare->tracer->sampling)->toBeFalse();
-
-    $flare->lifecycle->endSubtask();
-
-    $flare->lifecycle->startSubtask();
-
-    expect($flare->tracer->sampling)->toBeTrue();
-
-    $flare->lifecycle->endSubtask();
-});

--- a/tests/Support/LifecylceTest.php
+++ b/tests/Support/LifecylceTest.php
@@ -376,3 +376,49 @@ it('completes the lifecycle correctly when span limit is reached before lifecycl
             'done' => true,
         ]);
 });
+
+it('resets trace state after an unsampled subtask so the next subtask can sample', function () {
+    $flare = setupFlare(fn (FlareConfig $config) => $config->sampleRate(1.0), isUsingSubtasks: true);
+
+    $flare->lifecycle->startSubtask(
+        $flare->ids->traceParent($flare->ids->trace(), $flare->ids->span(), sampling: false)
+    );
+
+    expect($flare->tracer->sampling)->toBeFalse();
+
+    $flare->lifecycle->endSubtask();
+
+    expect($flare->tracer->currentTraceId())->toBeNull();
+
+    $traceId = $flare->ids->trace();
+
+    $flare->lifecycle->startSubtask(
+        $flare->ids->traceParent($traceId, $flare->ids->span(), sampling: true)
+    );
+
+    expect($flare->tracer->sampling)->toBeTrue();
+    expect($flare->tracer->currentTraceId())->toBe($traceId);
+
+    $flare->lifecycle->endSubtask();
+});
+
+it('asks the sampler again for each subtask without a traceparent', function () {
+    FakeSampler::setRandoms(0.9, 0.1);
+
+    $flare = setupFlare(
+        fn (FlareConfig $config) => $config->sampler(FakeSampler::class, ['rate' => 0.5]),
+        isUsingSubtasks: true
+    );
+
+    $flare->lifecycle->startSubtask();
+
+    expect($flare->tracer->sampling)->toBeFalse();
+
+    $flare->lifecycle->endSubtask();
+
+    $flare->lifecycle->startSubtask();
+
+    expect($flare->tracer->sampling)->toBeTrue();
+
+    $flare->lifecycle->endSubtask();
+});

--- a/tests/TracerTest.php
+++ b/tests/TracerTest.php
@@ -562,6 +562,23 @@ it('clears paused state on unsample so a stray resume cannot revive an unsampled
     expect($tracer->isSamplingPaused())->toBeFalse();
 });
 
+it('clears paused state when a trace ends so a stray resume cannot sample the next trace', function () {
+    $tracer = setupFlare(alwaysSampleTraces: true)->tracer;
+
+    $tracer->startTrace();
+    $tracer->pauseSampling();
+
+    expect($tracer->isSamplingPaused())->toBeTrue();
+
+    $tracer->endTrace();
+
+    expect($tracer->isSamplingPaused())->toBeFalse();
+
+    $tracer->resumeSampling();
+
+    expect($tracer->isSampling())->toBeFalse();
+});
+
 it('does not enter pause tracking when sampling is already off', function () {
     $tracer = setupFlare(alwaysSampleTraces: false)->tracer;
 


### PR DESCRIPTION
Closes #90.

`Lifecycle::endSubtask()` only called `Tracer::endTrace()` when the subtask was sampled:

```php
if ($this->tracer->sampling === true) {
    $this->tracer->endTrace();
}
```

`Tracer::startTrace()` sets `$currentTraceId` for every trace, sampled or not, and only `endTrace()` and `unsample()` clear it. So after an unsampled subtask the trace id stayed set and the next subtask hit the early return in `startTrace()`:

```php
if ($this->currentTraceId !== null) {
    return $this->sampling; // false, forever
}
```

The next job's traceparent was never parsed and the sampler was never asked again. A queue worker recorded nothing after its first unsampled job until the process restarted.

This only affected subtask mode (`horizon:work`, `queue:work`, `vapor:work`, `serve`, Octane). The request and command path uses `Lifecycle::terminated()`, which already called `endTrace()` in its unsampled branch.

`endSubtask()` now calls `endTrace()` unconditionally. That is safe because `endTrace()` returns early when there are no spans.

While in there, `Tracer::endTrace()` now also resets `$paused`. It reset `currentTraceId`, `currentSpanId`, `currentSpanIdAvailable` and `sampling`, but not `$paused` (`unsample()` did). A trace that ended while sampling was paused could be revived by the next `resumeSampling()`, which flipped `sampling` to true on a trace that never got a sampling decision.

The `startTrace()` guard is left as is on purpose. It is what makes repeated `start()` calls idempotent, and loosening it would hide lifecycle bugs instead of surfacing them.
