### PR TITLE
Check whether an entity is enabled before running its pre-checks in flare:test

### DIFF
--- a/shared/FakeSymfonyTester.php
+++ b/shared/FakeSymfonyTester.php
@@ -136,10 +136,6 @@ class FakeSymfonyTester extends SymfonyTester
 
     protected function preCheckEntity(FlareEntityType $type): bool
     {
-        if (! parent::preCheckEntity($type)) {
-            return false;
-        }
-
         if ($this->preCheckCallback === null) {
             return true;
         }

--- a/src/Support/Tester.php
+++ b/src/Support/Tester.php
@@ -64,15 +64,17 @@ abstract class Tester
         $success = true;
 
         foreach ($this->testEntityTypes() as $entityType) {
+            if (! $this->isEntityEnabled($entityType)) {
+                $this->writeLine("⏭️ {$this->entityDisabledMessage($entityType)}", self::STYLE_INFO);
+
+                continue;
+            }
+
             if (! $this->preCheckEntity($entityType)) {
                 return false;
             }
 
-            if (! $this->isEntityEnabled($entityType)) {
-                $this->writeLine("❌ {$this->entityDisabledMessage($entityType)}", self::STYLE_INFO);
-
-                continue;
-            }
+            $this->warnAboutEntity($entityType);
 
             $success = $this->sendTestPayload($entityType) && $success;
         }
@@ -133,6 +135,11 @@ abstract class Tester
 
     protected function preCheckEntity(FlareEntityType $type): bool
     {
+        return true;
+    }
+
+    protected function warnAboutEntity(FlareEntityType $type): void
+    {
         if ($type === FlareEntityType::Errors
             && $this->shouldWarnAboutStackFrameArgumentsIniSetting($this->stackFrameArgumentsEnabled())
         ) {
@@ -142,8 +149,6 @@ abstract class Tester
         if ($type === FlareEntityType::Logs && $this->config->sender !== DaemonSender::class) {
             $this->writeLine('⚠️ Logs are being sent without the Flare daemon. We recommend using the daemon sender for better performance and reliability.', self::STYLE_WARNING);
         }
-
-        return true;
     }
 
     protected function isEntityEnabled(FlareEntityType $type): bool

--- a/tests/Support/SymfonyTester.php
+++ b/tests/Support/SymfonyTester.php
@@ -358,10 +358,10 @@ it('skips the pre-check of a disabled entity and keeps testing the other types',
     setupFlare();
 
     $tester = FakeSymfonyTester::create(options: ['errors' => true, 'logs' => true]);
-    $tester->entityEnabled = [FlareEntityType::Logs->value => false];
+    $tester->entityEnabled = [FlareEntityType::Errors->value => false];
     $tester->preCheckCallback = function (FlareEntityType $type, FakeSymfonyTester $tester): bool {
-        if ($type === FlareEntityType::Logs) {
-            $tester->writeLinePublic('Custom pre-check failed for logs');
+        if ($type === FlareEntityType::Errors) {
+            $tester->writeLinePublic('Custom pre-check failed for errors');
 
             return false;
         }
@@ -372,10 +372,9 @@ it('skips the pre-check of a disabled entity and keeps testing the other types',
     expect($tester->run())->toBeTrue();
 
     $text = $tester->output();
-    expect($text)->toContain('Logging is disabled');
-    expect($text)->not->toContain('Custom pre-check failed for logs');
-    expect($text)->not->toContain('Logs are being sent without the Flare daemon');
-    expect($text)->toContain('Error sent to Flare');
+    expect($text)->toContain('Error reporting is disabled');
+    expect($text)->not->toContain('Custom pre-check failed for errors');
+    expect($text)->toContain('Log sent to Flare');
 
-    FakeApi::assertSent(reports: 1, logs: 0);
+    FakeApi::assertSent(reports: 0, logs: 1);
 });

--- a/tests/Support/SymfonyTester.php
+++ b/tests/Support/SymfonyTester.php
@@ -353,3 +353,29 @@ it('renders the failure block including the extra environment rows when sending 
     expect($text)->toContain('1.2.3');
     expect($text)->toContain('Platform');
 });
+
+it('skips the pre-check of a disabled entity and keeps testing the other types', function () {
+    setupFlare();
+
+    $tester = FakeSymfonyTester::create(options: ['errors' => true, 'logs' => true]);
+    $tester->entityEnabled = [FlareEntityType::Logs->value => false];
+    $tester->preCheckCallback = function (FlareEntityType $type, FakeSymfonyTester $tester): bool {
+        if ($type === FlareEntityType::Logs) {
+            $tester->writeLinePublic('Custom pre-check failed for logs');
+
+            return false;
+        }
+
+        return true;
+    };
+
+    expect($tester->run())->toBeTrue();
+
+    $text = $tester->output();
+    expect($text)->toContain('Logging is disabled');
+    expect($text)->not->toContain('Custom pre-check failed for logs');
+    expect($text)->not->toContain('Logs are being sent without the Flare daemon');
+    expect($text)->toContain('Error sent to Flare');
+
+    FakeApi::assertSent(reports: 1, logs: 0);
+});

--- a/tests/Support/SymfonyTester.php
+++ b/tests/Support/SymfonyTester.php
@@ -378,3 +378,23 @@ it('skips the pre-check of a disabled entity and keeps testing the other types',
 
     FakeApi::assertSent(reports: 0, logs: 1);
 });
+
+it('does not warn about an entity that is disabled', function () {
+    setupFlare();
+
+    $enabled = FakeSymfonyTester::create(options: ['logs' => true]);
+
+    expect($enabled->run())->toBeTrue();
+    expect($enabled->output())->toContain('Logs are being sent without the Flare daemon');
+
+    $disabled = FakeSymfonyTester::create(options: ['logs' => true]);
+    $disabled->entityEnabled = [FlareEntityType::Logs->value => false];
+
+    expect($disabled->run())->toBeTrue();
+
+    $text = $disabled->output();
+    expect($text)->toContain('Logging is disabled');
+    expect($text)->not->toContain('Logs are being sent without the Flare daemon');
+
+    FakeApi::assertSent(logs: 1);
+});


### PR DESCRIPTION
`Tester::run()` ran an entity's configuration pre-checks before checking whether that entity was enabled, so a switched-off feature still ran its checks, and a failing check aborted the whole command before the "this feature is disabled" message was ever printed. Concretely, with `log` set to false, `flare:test` told the user their `flare` log channel was missing from the default logging stack and exited, so they fixed the wrong thing and only learned logging was disabled on the next run. This swaps the two checks so disabled entities skip their pre-checks entirely and the run continues with the remaining types.

While in there, the warnings moved out of `preCheckEntity()` into a new `warnAboutEntity()` that runs after the pre-checks pass, so a hard error about logging not being wired up is no longer preceded by a warning describing how logs are sent. The skipped-entity line also now uses ⏭️ instead of ❌, since the command exits zero in that case and nothing is actually broken.

Verified downstream against a local `spatie/laravel-flare` checkout, where `LaravelTester` overrides `preCheckEntity()`; its `TestCommandTest` suite still passes.