### PR TITLE
Dump the Flare configuration when running the tester in debug verbosity

### DIFF
--- a/shared/FakeSymfonyTester.php
+++ b/shared/FakeSymfonyTester.php
@@ -81,6 +81,12 @@ class FakeSymfonyTester extends SymfonyTester
         return $this->bufferedOutput->fetch();
     }
 
+    public function setVerbosity(int $verbosity): void
+    {
+        $this->bufferedOutput->setVerbosity($verbosity);
+        $this->output->setVerbosity($verbosity);
+    }
+
     public function sendErrorPayload(): void
     {
         parent::sendErrorPayload();

--- a/shared/FakeSymfonyTester.php
+++ b/shared/FakeSymfonyTester.php
@@ -81,11 +81,6 @@ class FakeSymfonyTester extends SymfonyTester
         return $this->bufferedOutput->fetch();
     }
 
-    public function setVerbosity(int $verbosity): void
-    {
-        $this->bufferedOutput->setVerbosity($verbosity);
-        $this->output->setVerbosity($verbosity);
-    }
 
     public function sendErrorPayload(): void
     {

--- a/src/Support/SymfonyTester.php
+++ b/src/Support/SymfonyTester.php
@@ -91,6 +91,19 @@ class SymfonyTester extends Tester
         $this->io->newLine();
     }
 
+    /** @return array<string, mixed> */
+    protected function debugSections(): array
+    {
+        if (! $this->output->isDebug()) {
+            return [];
+        }
+
+        $config = clone $this->config;
+        $config->apiToken = '<redacted>';
+
+        return ['Flare config' => $config];
+    }
+
     protected function buildEntryPoint(): EntryPoint
     {
         $entryPoint = new EntryPoint(

--- a/src/Support/SymfonyTester.php
+++ b/src/Support/SymfonyTester.php
@@ -91,15 +91,6 @@ class SymfonyTester extends Tester
         $this->io->newLine();
     }
 
-    protected function writeDebugSections(): void
-    {
-        if (! $this->output->isDebug()) {
-            return;
-        }
-
-        parent::writeDebugSections();
-    }
-
     /** @return array<string, mixed> */
     protected function debugSections(): array
     {

--- a/src/Support/SymfonyTester.php
+++ b/src/Support/SymfonyTester.php
@@ -91,13 +91,18 @@ class SymfonyTester extends Tester
         $this->io->newLine();
     }
 
+    protected function writeDebugSections(): void
+    {
+        if (! $this->output->isDebug()) {
+            return;
+        }
+
+        parent::writeDebugSections();
+    }
+
     /** @return array<string, mixed> */
     protected function debugSections(): array
     {
-        if (! $this->output->isDebug()) {
-            return [];
-        }
-
         $config = clone $this->config;
         $config->apiToken = '<redacted>';
 

--- a/src/Support/Tester.php
+++ b/src/Support/Tester.php
@@ -50,11 +50,13 @@ abstract class Tester
 
     abstract protected function writeNewline(): void;
 
-    public function run(): bool
+    public function run(bool $debug = false): bool
     {
         $success = $this->runTests();
 
-        $this->writeDebugSections();
+        if ($debug) {
+            $this->writeDebugSections();
+        }
 
         return $success;
     }

--- a/src/Support/Tester.php
+++ b/src/Support/Tester.php
@@ -52,6 +52,8 @@ abstract class Tester
 
     public function run(): bool
     {
+        $this->writeDebugSections();
+
         if (empty($this->config->apiToken)) {
             $this->writeLine('❌ Flare key not specified. Make sure you specify a value in the `key` setting of your Flare configuration.', self::STYLE_ERROR);
 
@@ -361,6 +363,21 @@ abstract class Tester
             ['Curl', curl_version()['version'] ?? 'Unknown'],
             ['SSL', curl_version()['ssl_version'] ?? 'Unknown'],
         ];
+    }
+
+    /** @return array<string, mixed> */
+    protected function debugSections(): array
+    {
+        return [];
+    }
+
+    protected function writeDebugSections(): void
+    {
+        foreach ($this->debugSections() as $label => $value) {
+            $this->writeLine($label, self::STYLE_INFO);
+            $this->writeLine(print_r($value, true));
+            $this->writeNewline();
+        }
     }
 
     protected function writeEnvironmentInfo(): void

--- a/src/Support/Tester.php
+++ b/src/Support/Tester.php
@@ -52,8 +52,15 @@ abstract class Tester
 
     public function run(): bool
     {
+        $success = $this->runTests();
+
         $this->writeDebugSections();
 
+        return $success;
+    }
+
+    protected function runTests(): bool
+    {
         if (empty($this->config->apiToken)) {
             $this->writeLine('❌ Flare key not specified. Make sure you specify a value in the `key` setting of your Flare configuration.', self::STYLE_ERROR);
 

--- a/tests/Support/SymfonyTesterTest.php
+++ b/tests/Support/SymfonyTesterTest.php
@@ -12,7 +12,6 @@ use Spatie\FlareClient\Tests\Shared\FakeApi;
 use Spatie\FlareClient\Tests\Shared\FakeSender;
 use Spatie\FlareClient\Tests\Shared\FakeSymfonyTester;
 use Spatie\FlareClient\Tests\Shared\FakeTime;
-use Symfony\Component\Console\Output\OutputInterface;
 
 beforeEach(function () {
     FakeTime::setup('2019-01-01 12:34:56');
@@ -404,9 +403,8 @@ it('dumps the Flare config when the output is in debug verbosity', function () {
     setupFlare();
 
     $tester = FakeSymfonyTester::create(options: ['logs' => true]);
-    $tester->setVerbosity(OutputInterface::VERBOSITY_DEBUG);
 
-    expect($tester->run())->toBeTrue();
+    expect($tester->run(debug: true))->toBeTrue();
 
     $text = $tester->output();
     expect($text)->toContain('Flare config');
@@ -419,16 +417,15 @@ it('dumps the Flare config in debug verbosity even when no api key is set', func
     setupFlare();
 
     $tester = FakeSymfonyTester::create(options: ['logs' => true], config: new FlareConfig(apiToken: null));
-    $tester->setVerbosity(OutputInterface::VERBOSITY_DEBUG);
 
-    expect($tester->run())->toBeFalse();
+    expect($tester->run(debug: true))->toBeFalse();
 
     $text = $tester->output();
     expect($text)->toContain('Flare key not specified');
     expect($text)->toContain('Flare config');
 });
 
-it('does not dump the Flare config on normal verbosity', function () {
+it('does not dump the Flare config when debug is not requested', function () {
     setupFlare();
 
     $tester = FakeSymfonyTester::create(options: ['logs' => true]);

--- a/tests/Support/SymfonyTesterTest.php
+++ b/tests/Support/SymfonyTesterTest.php
@@ -10,9 +10,9 @@ use Spatie\FlareClient\Senders\Exceptions\BadResponseCode;
 use Spatie\FlareClient\Senders\Support\Response;
 use Spatie\FlareClient\Tests\Shared\FakeApi;
 use Spatie\FlareClient\Tests\Shared\FakeSender;
-use Symfony\Component\Console\Output\OutputInterface;
 use Spatie\FlareClient\Tests\Shared\FakeSymfonyTester;
 use Spatie\FlareClient\Tests\Shared\FakeTime;
+use Symfony\Component\Console\Output\OutputInterface;
 
 beforeEach(function () {
     FakeTime::setup('2019-01-01 12:34:56');

--- a/tests/Support/SymfonyTesterTest.php
+++ b/tests/Support/SymfonyTesterTest.php
@@ -412,6 +412,20 @@ it('dumps the Flare config when the output is in debug verbosity', function () {
     expect($text)->toContain('Flare config');
     expect($text)->toContain('<redacted>');
     expect($text)->not->toContain('fake-api-key');
+    expect(strpos($text, 'Flare config'))->toBeGreaterThan(strpos($text, 'Log sent to Flare'));
+});
+
+it('dumps the Flare config in debug verbosity even when no api key is set', function () {
+    setupFlare();
+
+    $tester = FakeSymfonyTester::create(options: ['logs' => true], config: new FlareConfig(apiToken: null));
+    $tester->setVerbosity(OutputInterface::VERBOSITY_DEBUG);
+
+    expect($tester->run())->toBeFalse();
+
+    $text = $tester->output();
+    expect($text)->toContain('Flare key not specified');
+    expect($text)->toContain('Flare config');
 });
 
 it('does not dump the Flare config on normal verbosity', function () {

--- a/tests/Support/SymfonyTesterTest.php
+++ b/tests/Support/SymfonyTesterTest.php
@@ -10,6 +10,7 @@ use Spatie\FlareClient\Senders\Exceptions\BadResponseCode;
 use Spatie\FlareClient\Senders\Support\Response;
 use Spatie\FlareClient\Tests\Shared\FakeApi;
 use Spatie\FlareClient\Tests\Shared\FakeSender;
+use Symfony\Component\Console\Output\OutputInterface;
 use Spatie\FlareClient\Tests\Shared\FakeSymfonyTester;
 use Spatie\FlareClient\Tests\Shared\FakeTime;
 
@@ -397,4 +398,27 @@ it('does not warn about an entity that is disabled', function () {
     expect($text)->not->toContain('Logs are being sent without the Flare daemon');
 
     FakeApi::assertSent(logs: 1);
+});
+
+it('dumps the Flare config when the output is in debug verbosity', function () {
+    setupFlare();
+
+    $tester = FakeSymfonyTester::create(options: ['logs' => true]);
+    $tester->setVerbosity(OutputInterface::VERBOSITY_DEBUG);
+
+    expect($tester->run())->toBeTrue();
+
+    $text = $tester->output();
+    expect($text)->toContain('Flare config');
+    expect($text)->toContain('<redacted>');
+    expect($text)->not->toContain('fake-api-key');
+});
+
+it('does not dump the Flare config on normal verbosity', function () {
+    setupFlare();
+
+    $tester = FakeSymfonyTester::create(options: ['logs' => true]);
+
+    expect($tester->run())->toBeTrue();
+    expect($tester->output())->not->toContain('Flare config');
 });


### PR DESCRIPTION
Running the tester at `-vvv` now prints the resolved `FlareConfig` before anything else, so a support ticket can include what Flare actually resolved rather than what the user thinks they configured. It runs before the API key check, so the dump still appears when the key is missing. `apiToken` is redacted, since the whole point is pasting this to someone else.

`debugSections()` mirrors the existing `environmentInfo()` hook, so integrations can add their own sections. `spatie/laravel-flare` will use it to append its `logging` config, which the client cannot know about. `SymfonyTester` supplies the `-vvv` detection and the `CliDumper` output, and the abstract `Tester` falls back to `print_r`.

One thing worth a look beyond the feature: `tests/Support/SymfonyTester.php` has never run in CI. PHPUnit's default suffix is `Test.php`, and every other file in that directory follows it, so this one was silently skipped. Renaming it to `SymfonyTesterTest.php` brings 23 tests into the suite, 493 to 516, all passing with no changes needed.