### PR TITLE
Fix external HTTP spans leaking and missing error information

### DIFF
--- a/src/Recorders/ExternalHttpRecorder/ExternalHttpRecorder.php
+++ b/src/Recorders/ExternalHttpRecorder/ExternalHttpRecorder.php
@@ -3,6 +3,7 @@
 namespace Spatie\FlareClient\Recorders\ExternalHttpRecorder;
 
 use Spatie\FlareClient\Enums\RecorderType;
+use Spatie\FlareClient\Enums\SpanStatusCode;
 use Spatie\FlareClient\Enums\SpanType;
 use Spatie\FlareClient\Recorders\SpansRecorder;
 use Spatie\FlareClient\Spans\Span;
@@ -60,19 +61,35 @@ class ExternalHttpRecorder extends SpansRecorder
         int $responseCode,
         ?int $responseBodySize = null,
         array $responseHeaders = [],
+        ?string $errorType = null,
     ): ?Span {
-        return $this->endSpan(additionalAttributes:  [
+        $errorType ??= $responseCode >= 400 ? (string) $responseCode : null;
+
+        $attributes = [
             'http.response.status_code' => $responseCode,
             'http.response.body.size' => $responseBodySize,
             'http.response.headers' => $this->redactor->censorHeaders($responseHeaders),
-        ]);
+        ];
+
+        if ($errorType !== null) {
+            $attributes['error.type'] = $errorType;
+        }
+
+        return $this->endSpan(
+            additionalAttributes: $attributes,
+            spanCallback: $errorType === null
+                ? null
+                : fn (Span $span) => $span->setStatus(SpanStatusCode::Error, $errorType),
+        );
     }
 
-    public function recordConnectionFailed(
-        string $errorType
-    ): ?Span {
-        return $this->endSpan(additionalAttributes:  [
-            'error.type' => $errorType,
-        ]);
+    public function recordConnectionFailed(string $errorType): ?Span
+    {
+        return $this->endSpan(
+            additionalAttributes: [
+                'error.type' => $errorType,
+            ],
+            spanCallback: fn (Span $span) => $span->setStatus(SpanStatusCode::Error, $errorType),
+        );
     }
 }

--- a/src/Recorders/ExternalHttpRecorder/Guzzle/FlareHandlerStack.php
+++ b/src/Recorders/ExternalHttpRecorder/Guzzle/FlareHandlerStack.php
@@ -3,17 +3,25 @@
 namespace Spatie\FlareClient\Recorders\ExternalHttpRecorder\Guzzle;
 
 use GuzzleHttp\HandlerStack;
+use GuzzleHttp\Promise\PromiseInterface;
+use Psr\Http\Message\RequestInterface;
+use Psr\Http\Message\ResponseInterface;
 use Spatie\FlareClient\Flare;
 
 class FlareHandlerStack
 {
+    /**
+     * @param (callable(RequestInterface, array<array-key, mixed>): PromiseInterface<ResponseInterface, mixed>)|null $handler
+     *
+     * @return HandlerStack<callable(RequestInterface, array<array-key, mixed>): PromiseInterface<ResponseInterface, mixed>>
+     */
     public static function create(
         Flare $flare,
         ?callable $handler = null
     ): HandlerStack {
-        $stack = new HandlerStack($handler);
+        $stack = HandlerStack::create($handler);
 
-        $stack->push(new FlareMiddleware($flare));
+        $stack->push(new FlareMiddleware($flare), 'flare');
 
         return $stack;
     }

--- a/src/Recorders/ExternalHttpRecorder/Guzzle/FlareMiddleware.php
+++ b/src/Recorders/ExternalHttpRecorder/Guzzle/FlareMiddleware.php
@@ -64,7 +64,7 @@ class FlareMiddleware
 
     protected function recordFailure(mixed $reason): void
     {
-        $errorType = is_object($reason) ? $reason::class : get_debug_type($reason);
+        $errorType = get_debug_type($reason);
 
         $response = $this->responseFromFailure($reason);
 

--- a/src/Recorders/ExternalHttpRecorder/Guzzle/FlareMiddleware.php
+++ b/src/Recorders/ExternalHttpRecorder/Guzzle/FlareMiddleware.php
@@ -2,6 +2,10 @@
 
 namespace Spatie\FlareClient\Recorders\ExternalHttpRecorder\Guzzle;
 
+use Closure;
+use GuzzleHttp\Promise\Create;
+use GuzzleHttp\Promise\PromiseInterface;
+use Psr\Http\Message\MessageInterface;
 use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\ResponseInterface;
 use Spatie\FlareClient\Flare;
@@ -13,29 +17,35 @@ class FlareMiddleware
     {
     }
 
-    public function __invoke(callable $handler): callable
+    public function __invoke(callable $handler): Closure
     {
-        return function (RequestInterface $request, array $options) use ($handler) {
+        return function (RequestInterface $request, array $options) use ($handler): PromiseInterface {
             $this->flare->externalHttp()?->recordSending(
                 url: (string) $request->getUri(),
                 method: $request->getMethod(),
                 bodySize: $request->getBody()->getSize() ?: 0,
-                headers:$this->getHeaders($request),
+                headers: $this->getHeaders($request),
             );
 
-            return $handler($request, $options)->then(
-                $this->onSuccess(),
-                $this->onError()
-            );
+            try {
+                return $handler($request, $options)->then(
+                    $this->recordFulfilled(),
+                    $this->recordRejected(),
+                );
+            } catch (Throwable $throwable) {
+                $this->recordFailure($throwable);
+
+                throw $throwable;
+            }
         };
     }
 
-    protected function onSuccess(): callable
+    protected function recordFulfilled(): Closure
     {
-        return function (ResponseInterface $response) {
+        return function (ResponseInterface $response): ResponseInterface {
             $this->flare->externalHttp()?->recordReceived(
                 responseCode: $response->getStatusCode(),
-                responseBodySize: $response->getBody()->getSize() ?: 0,
+                responseBodySize: $this->getBodySize($response),
                 responseHeaders: $this->getHeaders($response),
             );
 
@@ -43,34 +53,69 @@ class FlareMiddleware
         };
     }
 
-    protected function onError(): callable
+    protected function recordRejected(): Closure
     {
-        return function (Throwable $reason) {
-            if (method_exists($reason, 'getResponse') && $reason->getResponse() instanceof ResponseInterface) {
-                $response = $reason->getResponse();
+        return function (mixed $reason): PromiseInterface {
+            $this->recordFailure($reason);
 
-                $this->flare->externalHttp()?->recordReceived(
-                    responseCode: $response->getStatusCode(),
-                    responseBodySize: $response->getBody()->getSize() ?: 0,
-                    responseHeaders: $this->getHeaders($response),
-                );
-
-                throw $reason;
-            }
-            $errorMessage = $reason->getMessage();
-
-            $this->flare->externalHttp()?->recordConnectionFailed($errorMessage);
-
-            throw $reason;
+            return Create::rejectionFor($reason);
         };
     }
 
-    protected function getHeaders(RequestInterface|ResponseInterface $requestResponse): array
+    protected function recordFailure(mixed $reason): void
+    {
+        $errorType = is_object($reason) ? $reason::class : get_debug_type($reason);
+
+        $response = $this->responseFromFailure($reason);
+
+        if ($response !== null) {
+            $this->flare->externalHttp()?->recordReceived(
+                responseCode: $response->getStatusCode(),
+                responseBodySize: $this->getBodySize($response),
+                responseHeaders: $this->getHeaders($response),
+                errorType: $errorType,
+            );
+
+            return;
+        }
+
+        $this->flare->externalHttp()?->recordConnectionFailed($errorType);
+    }
+
+    protected function responseFromFailure(mixed $reason): ?ResponseInterface
+    {
+        if (! is_object($reason)) {
+            return null;
+        }
+
+        if (! method_exists($reason, 'getResponse')) {
+            return null;
+        }
+
+        $response = $reason->getResponse();
+
+        return $response instanceof ResponseInterface ? $response : null;
+    }
+
+    protected function getBodySize(ResponseInterface $response): ?int
+    {
+        if ($response->getHeaderLine('Transfer-Encoding') === 'chunked') {
+            return null;
+        }
+
+        if ($response->hasHeader('Content-Length')) {
+            return (int) $response->getHeaderLine('Content-Length');
+        }
+
+        return $response->getBody()->getSize() ?: null;
+    }
+
+    protected function getHeaders(MessageInterface $message): array
     {
         $headers = [];
 
-        foreach ($requestResponse->getHeaders() as $name => $value) {
-            $headers[$name] = implode(', ', $value);
+        foreach ($message->getHeaders() as $name => $values) {
+            $headers[$name] = implode(', ', $values);
 
             if (empty($headers[$name])) {
                 unset($headers[$name]);

--- a/tests/Recorders/ExternalHttpRecorder/Guzzle/FlareMiddlewareTest.php
+++ b/tests/Recorders/ExternalHttpRecorder/Guzzle/FlareMiddlewareTest.php
@@ -1,14 +1,19 @@
 <?php
 
 use GuzzleHttp\Client;
+use GuzzleHttp\Exception\BadResponseException;
 use GuzzleHttp\Exception\RequestException;
 use GuzzleHttp\Handler\MockHandler;
+use GuzzleHttp\Promise\Promise;
+use GuzzleHttp\Promise\Utils as PromiseUtils;
 use GuzzleHttp\Psr7\Request;
 use GuzzleHttp\Psr7\Response;
 use GuzzleHttp\Utils;
+use Spatie\FlareClient\Enums\SpanStatusCode;
 use Spatie\FlareClient\Enums\SpanType;
 use Spatie\FlareClient\FlareConfig;
 use Spatie\FlareClient\Recorders\ExternalHttpRecorder\Guzzle\FlareHandlerStack;
+use Spatie\FlareClient\Recorders\ExternalHttpRecorder\Guzzle\FlareMiddleware;
 
 test('middleware records successful requests and responses', function () {
     $flare = setupFlare(fn (FlareConfig $config) => $config->alwaysSampleTraces()->collectExternalHttp());
@@ -56,6 +61,7 @@ test('middleware records successful requests and responses', function () {
             'Host' => 'example.com',
             'Accept' => 'application/json',
             'X-Test-Header' => 'test-value',
+            'Content-Length' => '13',
         ])
         ->toHaveKey('http.response.status_code', 200)
         ->toHaveKey('http.response.body.size', 16)
@@ -110,7 +116,10 @@ test('middleware records HTTP error responses', function () {
         ->toHaveKey('http.response.body.size', 21)
         ->toHaveKey('http.response.headers', [
             'Content-Type' => 'application/json',
-        ]);
+        ])
+        ->toHaveKey('error.type', '404');
+
+    expect($span->status?->code)->toBe(SpanStatusCode::Error);
 });
 
 test('middleware records connection errors', function () {
@@ -139,7 +148,9 @@ test('middleware records connection errors', function () {
 
     expect($span->attributes)
         ->toHaveKey('flare.span_type', SpanType::HttpRequest)
-        ->toHaveKey('error.type', 'Connection timed out');
+        ->toHaveKey('error.type', RequestException::class);
+
+    expect($span->status?->code)->toBe(SpanStatusCode::Error);
 });
 
 test('middleware correctly formats headers', function () {
@@ -191,4 +202,118 @@ test('middleware correctly formats headers', function () {
             'Set-Cookie' => 'cookie1=value1, cookie2=value2',
             'X-Multiple' => 'value1, value2, value3',
         ]);
+});
+
+/*
+ * Which response ends up on which span is not guaranteed for concurrent
+ * transfers, the recorder ends spans in the order they were started.
+ */
+test('middleware closes every span when requests run concurrently', function () {
+    $flare = setupFlare(fn (FlareConfig $config) => $config->alwaysSampleTraces()->collectExternalHttp());
+
+    $flare->tracer->startTrace();
+
+    $middleware = new FlareMiddleware($flare);
+
+    $promises = [];
+
+    $handler = $middleware(function (Request $request, array $options) use (&$promises) {
+        return $promises[$request->getUri()->getHost()] = new Promise();
+    });
+
+    $handler(new Request('GET', 'https://slow.test/'), []);
+    $handler(new Request('GET', 'https://fast.test/'), []);
+
+    $promises['slow.test']->resolve(new Response(500, ['Content-Length' => '5'], 'boom!'));
+    $promises['fast.test']->resolve(new Response(201, ['Content-Length' => '3'], 'abc'));
+
+    PromiseUtils::queue()->run();
+
+    $spans = array_values($flare->tracer->currentTrace());
+
+    expect($spans)->toHaveCount(2);
+
+    foreach ($spans as $span) {
+        expect($span)->end->not()->toBeNull();
+        expect($span->attributes)->toHaveKey('http.response.status_code');
+    }
+});
+
+test('middleware ends the span when the handler throws instead of rejecting', function () {
+    $flare = setupFlare(fn (FlareConfig $config) => $config->alwaysSampleTraces()->collectExternalHttp());
+
+    $flare->tracer->startTrace();
+
+    $middleware = new FlareMiddleware($flare);
+
+    $handler = $middleware(function (Request $request, array $options) {
+        throw new RuntimeException('Something went wrong');
+    });
+
+    expect(fn () => $handler(new Request('GET', 'https://example.com'), []))
+        ->toThrow(RuntimeException::class);
+
+    $span = array_values($flare->tracer->currentTrace())[0];
+
+    expect($span)->end->not()->toBeNull();
+    expect($span->attributes)->toHaveKey('error.type', RuntimeException::class);
+    expect($span->status?->code)->toBe(SpanStatusCode::Error);
+});
+
+test('middleware records a rejection carrying a response as received', function () {
+    $flare = setupFlare(fn (FlareConfig $config) => $config->alwaysSampleTraces()->collectExternalHttp());
+
+    $flare->tracer->startTrace();
+
+    $request = new Request('GET', 'https://example.com');
+    $response = new Response(200, ['Transfer-Encoding' => 'chunked'], 'truncated');
+
+    $mockHandler = new MockHandler([
+        new BadResponseException('Body could not be read', $request, $response),
+    ]);
+
+    $client = new Client(['handler' => FlareHandlerStack::create($flare, $mockHandler)]);
+
+    expect(fn () => $client->request('GET', 'https://example.com'))
+        ->toThrow(BadResponseException::class);
+
+    $span = array_values($flare->tracer->currentTrace())[0];
+
+    expect($span->attributes)
+        ->toHaveKey('http.response.status_code', 200)
+        ->toHaveKey('http.response.body.size', null)
+        ->toHaveKey('error.type', BadResponseException::class);
+
+    expect($span->status?->code)->toBe(SpanStatusCode::Error);
+});
+
+test('middleware records every redirect hop as its own span', function () {
+    $flare = setupFlare(fn (FlareConfig $config) => $config->alwaysSampleTraces()->collectExternalHttp());
+
+    $flare->tracer->startTrace();
+
+    $mockHandler = new MockHandler([
+        new Response(302, ['Location' => 'https://example.com/second']),
+        new Response(301, ['Location' => 'https://example.com/third']),
+        new Response(200, [], 'done'),
+    ]);
+
+    $client = new Client(['handler' => FlareHandlerStack::create($flare, $mockHandler)]);
+
+    $client->request('GET', 'https://example.com/first');
+
+    $spans = array_values($flare->tracer->currentTrace());
+
+    expect($spans)->toHaveCount(3);
+
+    foreach ($spans as $span) {
+        expect($span)->end->not()->toBeNull();
+        expect($span->status?->code)->toBeNull();
+    }
+
+    expect($spans[0]->attributes)->toHaveKey('http.response.status_code', 302);
+    expect($spans[1]->attributes)->toHaveKey('http.response.status_code', 301);
+    expect($spans[2]->attributes)->toHaveKey('http.response.status_code', 200);
+
+    expect($spans[0]->attributes)->not()->toHaveKey('error.type');
 });


### PR DESCRIPTION
Our Guzzle middleware could leave HTTP spans open forever. A handler that throws instead of returning a rejected promise skipped the `then` callbacks, so the span never got an end date. It now records through a try/catch, hands back `Create::rejectionFor()` so non-throwable rejection reasons keep working, and treats a rejection carrying a response as a received response instead of a connection failure.

While in there, `error.type` went from the exception message (unbounded) to the Guzzle exception class, 4xx and 5xx responses now get an `error.type` and an error span status following the OpenTelemetry HTTP conventions, and response body sizes read `Content-Length` so chunked responses report `null` instead of 0. `FlareHandlerStack::create()` also built a bare stack without Guzzle's defaults, so redirects were never followed. It delegates to `HandlerStack::create()` now, with our middleware pushed below the redirect middleware, so every hop gets its own span.

One thing to check before this ships: spans for 4xx, 5xx and connection failures will start arriving with an error status where they were unset before.

Still not fixed: concurrent transfers can put a response on the wrong span. Nothing leaks, every span closes, but pooled requests nest and can report a sibling's status code. Doing that properly needs context propagation in the tracer, so it's v4 material.