### PR TITLE
Let job and queue sampling rules decide per job

### DIFF
--- a/src/Recorders/JobRecorder/JobRecorder.php
+++ b/src/Recorders/JobRecorder/JobRecorder.php
@@ -89,32 +89,15 @@ class JobRecorder extends SpansRecorder
             return null;
         }
 
-        if ($this->lifecycle->usesSubtasks) {
-            $this->tracer->reevaluateSampling();
-        }
-
         return $this->startSpan(
             name: "Job - {$jobName}",
             attributes: fn () => [
                 'flare.span_type' => SpanType::Job,
                 ...$entryPoint->toAttributes(),
                 ...$jobAttributesProvider->toArray(),
-                ...$this->dispatchTraceAttributes(),
                 ...$attributes,
             ],
         );
-    }
-
-    /** @return array<string, string> */
-    protected function dispatchTraceAttributes(): array
-    {
-        $detachedFromTraceId = $this->tracer->detachedFromTraceId();
-
-        if ($detachedFromTraceId === null) {
-            return [];
-        }
-
-        return ['flare.dispatch.trace_id' => $detachedFromTraceId];
     }
 
     public function recordStartFromJob(

--- a/src/Recorders/JobRecorder/JobRecorder.php
+++ b/src/Recorders/JobRecorder/JobRecorder.php
@@ -62,6 +62,19 @@ class JobRecorder extends SpansRecorder
             $traceparent = $this->tracer->ids->setTraceparentSampling($traceparent, false);
         }
 
+        $entryPoint = new EntryPoint(
+            type: EntryPointType::Queue,
+            value: $jobClass ?? $jobName,
+        );
+
+        $entryPoint->setHandlerFromAttributesProvider($jobAttributesProvider);
+
+        // The entry point has to be known before the subtask starts, the sampler decides
+        // there and job/queue sampling rules can only match a resolved queue entry point.
+        if ($this->lifecycle->usesSubtasks) {
+            $this->entryPointResolver->set($entryPoint);
+        }
+
         $this->lifecycle->startSubtask(traceparent: $traceparent);
 
         if ($shouldIgnore && $this->lifecycle->usesSubtasks) {
@@ -76,16 +89,7 @@ class JobRecorder extends SpansRecorder
             return null;
         }
 
-        $entryPoint = new EntryPoint(
-            type: EntryPointType::Queue,
-            value: $jobClass ?? $jobName,
-        );
-
-        $entryPoint->setHandlerFromAttributesProvider($jobAttributesProvider);
-
         if ($this->lifecycle->usesSubtasks) {
-            $this->entryPointResolver->set($entryPoint);
-
             $this->tracer->reevaluateSampling();
         }
 
@@ -95,9 +99,22 @@ class JobRecorder extends SpansRecorder
                 'flare.span_type' => SpanType::Job,
                 ...$entryPoint->toAttributes(),
                 ...$jobAttributesProvider->toArray(),
+                ...$this->dispatchTraceAttributes(),
                 ...$attributes,
             ],
         );
+    }
+
+    /** @return array<string, string> */
+    protected function dispatchTraceAttributes(): array
+    {
+        $detachedFromTraceId = $this->tracer->detachedFromTraceId();
+
+        if ($detachedFromTraceId === null) {
+            return [];
+        }
+
+        return ['flare.dispatch.trace_id' => $detachedFromTraceId];
     }
 
     public function recordStartFromJob(

--- a/src/Tracer.php
+++ b/src/Tracer.php
@@ -45,10 +45,6 @@ class Tracer
 
     protected bool $currentSpanIdAvailable = true;
 
-    protected ?bool $parentSampled = null;
-
-    protected ?string $detachedFromTraceId = null;
-
     /**
      * @param array{max_spans: int, max_attributes_per_span: int, max_span_events_per_span: int, max_attributes_per_span_event: int, max_attribute_size_in_kb?: int}|null $limits
      * @param Closure(Span):(void|Span)|null $configureSpansCallable
@@ -115,7 +111,6 @@ class Tracer
         $this->currentTraceId = $traceId ?? $this->ids->trace();
         $this->currentSpanId = $spanId ?? $this->ids->span();
         $this->currentSpanIdAvailable = $currentSpanAvailable;
-        $this->parentSampled = $parentSampled;
 
         if ($this->disabled === true) {
             return false;
@@ -126,33 +121,14 @@ class Tracer
             $parentSampled,
         );
 
-        $this->detachFromUnsampledParent();
-
-        return $this->sampling;
-    }
-
-    /**
-     * A sampling rule can decide to sample something whose parent was not sampled. The
-     * inherited trace never gets sent, so continuing it would produce a trace without a
-     * root span shared by every sibling. Start a new trace instead and remember where it
-     * came from.
-     */
-    protected function detachFromUnsampledParent(): void
-    {
-        if ($this->parentSampled !== false || $this->sampling === false) {
-            return;
+        // The inherited trace never gets sent, continuing it would produce a rootless trace
+        if ($parentSampled === false && $this->sampling === true) {
+            $this->currentTraceId = $this->ids->trace();
+            $this->currentSpanId = $this->ids->span();
+            $this->currentSpanIdAvailable = true;
         }
 
-        $this->detachedFromTraceId = $this->currentTraceId;
-        $this->currentTraceId = $this->ids->trace();
-        $this->currentSpanId = $this->ids->span();
-        $this->currentSpanIdAvailable = true;
-        $this->parentSampled = null;
-    }
-
-    public function detachedFromTraceId(): ?string
-    {
-        return $this->detachedFromTraceId;
+        return $this->sampling;
     }
 
     public function endTrace(): void
@@ -166,8 +142,6 @@ class Tracer
         $this->currentSpanId = null;
         $this->currentSpanIdAvailable = true;
         $this->sampling = false;
-        $this->parentSampled = null;
-        $this->detachedFromTraceId = null;
 
         if (empty($this->spans)) {
             return;
@@ -200,8 +174,6 @@ class Tracer
         }
 
         $this->sampling = true;
-
-        $this->detachFromUnsampledParent();
     }
 
     public function unsample(): void
@@ -215,8 +187,6 @@ class Tracer
         $this->currentSpanId = null;
         $this->currentSpanIdAvailable = true;
         $this->sampling = false;
-        $this->parentSampled = null;
-        $this->detachedFromTraceId = null;
         $this->spans = [];
     }
 

--- a/src/Tracer.php
+++ b/src/Tracer.php
@@ -45,6 +45,10 @@ class Tracer
 
     protected bool $currentSpanIdAvailable = true;
 
+    protected ?bool $parentSampled = null;
+
+    protected ?string $detachedFromTraceId = null;
+
     /**
      * @param array{max_spans: int, max_attributes_per_span: int, max_span_events_per_span: int, max_attributes_per_span_event: int, max_attribute_size_in_kb?: int}|null $limits
      * @param Closure(Span):(void|Span)|null $configureSpansCallable
@@ -111,15 +115,44 @@ class Tracer
         $this->currentTraceId = $traceId ?? $this->ids->trace();
         $this->currentSpanId = $spanId ?? $this->ids->span();
         $this->currentSpanIdAvailable = $currentSpanAvailable;
+        $this->parentSampled = $parentSampled;
 
         if ($this->disabled === true) {
             return false;
         }
 
-        return $this->sampling = $this->sampler->shouldSample(
+        $this->sampling = $this->sampler->shouldSample(
             $this->entryPointResolver->get(),
             $parentSampled,
         );
+
+        $this->detachFromUnsampledParent();
+
+        return $this->sampling;
+    }
+
+    /**
+     * A sampling rule can decide to sample something whose parent was not sampled. The
+     * inherited trace never gets sent, so continuing it would produce a trace without a
+     * root span shared by every sibling. Start a new trace instead and remember where it
+     * came from.
+     */
+    protected function detachFromUnsampledParent(): void
+    {
+        if ($this->parentSampled !== false || $this->sampling === false) {
+            return;
+        }
+
+        $this->detachedFromTraceId = $this->currentTraceId;
+        $this->currentTraceId = $this->ids->trace();
+        $this->currentSpanId = $this->ids->span();
+        $this->currentSpanIdAvailable = true;
+        $this->parentSampled = null;
+    }
+
+    public function detachedFromTraceId(): ?string
+    {
+        return $this->detachedFromTraceId;
     }
 
     public function endTrace(): void
@@ -133,6 +166,8 @@ class Tracer
         $this->currentSpanId = null;
         $this->currentSpanIdAvailable = true;
         $this->sampling = false;
+        $this->parentSampled = null;
+        $this->detachedFromTraceId = null;
 
         if (empty($this->spans)) {
             return;
@@ -165,6 +200,8 @@ class Tracer
         }
 
         $this->sampling = true;
+
+        $this->detachFromUnsampledParent();
     }
 
     public function unsample(): void
@@ -178,6 +215,8 @@ class Tracer
         $this->currentSpanId = null;
         $this->currentSpanIdAvailable = true;
         $this->sampling = false;
+        $this->parentSampled = null;
+        $this->detachedFromTraceId = null;
         $this->spans = [];
     }
 

--- a/tests/Recorders/JobRecorder/JobRecorderTest.php
+++ b/tests/Recorders/JobRecorder/JobRecorderTest.php
@@ -7,6 +7,7 @@ use Spatie\FlareClient\Enums\SpanType;
 use Spatie\FlareClient\FlareConfig;
 use Spatie\FlareClient\FlareMiddleware\AddJobInformation;
 use Spatie\FlareClient\Memory\SystemMemory;
+use Spatie\FlareClient\Sampling\SamplingRule;
 use Spatie\FlareClient\Tests\Shared\FakeIds;
 use Spatie\FlareClient\Tests\Shared\FakeMemory;
 
@@ -313,4 +314,87 @@ it('handles a retry loop cleanly in subtask mode', function () {
 
     expect(AddJobInformation::$usedTrackingUuid)->toBe('uuid-2');
     expect(AddJobInformation::$latestJob)->toBe($span2);
+});
+
+it('lets a job sampling rule override an inherited sampled parent decision', function () {
+    $traceparent = '00-1234567890abcdef1234567890abcdef-fedcba9876543210-01';
+
+    $flare = setupFlare(
+        fn (FlareConfig $config) => $config
+            ->collectJobs()
+            ->sampleTracesDynamic(baseRate: 1.0, rules: [SamplingRule::forJob('App\\Jobs\\Send', 0)]),
+        isUsingSubtasks: true,
+    );
+
+    $flare->job()->recordStartFromJob('App\\Jobs\\Send', 'App\\Jobs\\Send', traceparent: $traceparent);
+
+    expect($flare->tracer->isSampling())->toBeFalse();
+    expect($flare->tracer->currentTrace())->toBeEmpty();
+});
+
+it('keeps the parent trace when a job sampling rule agrees with a sampled parent', function () {
+    $traceparent = '00-1234567890abcdef1234567890abcdef-fedcba9876543210-01';
+
+    $flare = setupFlare(
+        fn (FlareConfig $config) => $config
+            ->collectJobs()
+            ->sampleTracesDynamic(baseRate: 0, rules: [SamplingRule::forJob('App\\Jobs\\Send', 1.0)]),
+        isUsingSubtasks: true,
+    );
+
+    $span = $flare->job()->recordStartFromJob('App\\Jobs\\Send', 'App\\Jobs\\Send', traceparent: $traceparent);
+
+    expect($span)->not()->toBeNull();
+    expect($span->traceId)->toBe('1234567890abcdef1234567890abcdef');
+    expect($span->attributes)->not()->toHaveKey('flare.dispatch.trace_id');
+});
+
+it('starts a new trace when a job sampling rule overrides an unsampled parent', function () {
+    FakeIds::setup()->nextTraceId('aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa');
+
+    $traceparent = '00-1234567890abcdef1234567890abcdef-fedcba9876543210-00';
+
+    $flare = setupFlare(
+        fn (FlareConfig $config) => $config
+            ->collectJobs()
+            ->sampleTracesDynamic(baseRate: 0, rules: [SamplingRule::forJob('App\\Jobs\\Send', 1.0)]),
+        isUsingSubtasks: true,
+    );
+
+    $span = $flare->job()->recordStartFromJob('App\\Jobs\\Send', 'App\\Jobs\\Send', traceparent: $traceparent);
+
+    expect($span)->not()->toBeNull();
+    expect($span->traceId)->toBe('aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa');
+    expect($span->parentSpanId)->toBeNull();
+    expect($span->attributes)->toHaveKey('flare.dispatch.trace_id', '1234567890abcdef1234567890abcdef');
+});
+
+it('keeps inheriting an unsampled parent when no job sampling rule matches', function () {
+    $traceparent = '00-1234567890abcdef1234567890abcdef-fedcba9876543210-00';
+
+    $flare = setupFlare(
+        fn (FlareConfig $config) => $config
+            ->collectJobs()
+            ->sampleTracesDynamic(baseRate: 1.0, rules: [SamplingRule::forJob('App\\Jobs\\Other', 1.0)]),
+        isUsingSubtasks: true,
+    );
+
+    $flare->job()->recordStartFromJob('App\\Jobs\\Send', 'App\\Jobs\\Send', traceparent: $traceparent);
+
+    expect($flare->tracer->isSampling())->toBeFalse();
+    expect($flare->tracer->currentTrace())->toBeEmpty();
+});
+
+it('applies a job sampling rule to a job dispatched without a traceparent', function () {
+    $flare = setupFlare(
+        fn (FlareConfig $config) => $config
+            ->collectJobs()
+            ->sampleTracesDynamic(baseRate: 0, rules: [SamplingRule::forJob('App\\Jobs\\Send', 1.0)]),
+        isUsingSubtasks: true,
+    );
+
+    $span = $flare->job()->recordStartFromJob('App\\Jobs\\Send', 'App\\Jobs\\Send');
+
+    expect($span)->not()->toBeNull();
+    expect($span->attributes)->not()->toHaveKey('flare.dispatch.trace_id');
 });

--- a/tests/Recorders/JobRecorder/JobRecorderTest.php
+++ b/tests/Recorders/JobRecorder/JobRecorderTest.php
@@ -346,7 +346,6 @@ it('keeps the parent trace when a job sampling rule agrees with a sampled parent
 
     expect($span)->not()->toBeNull();
     expect($span->traceId)->toBe('1234567890abcdef1234567890abcdef');
-    expect($span->attributes)->not()->toHaveKey('flare.dispatch.trace_id');
 });
 
 it('starts a new trace when a job sampling rule overrides an unsampled parent', function () {
@@ -366,7 +365,6 @@ it('starts a new trace when a job sampling rule overrides an unsampled parent', 
     expect($span)->not()->toBeNull();
     expect($span->traceId)->toBe('aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa');
     expect($span->parentSpanId)->toBeNull();
-    expect($span->attributes)->toHaveKey('flare.dispatch.trace_id', '1234567890abcdef1234567890abcdef');
 });
 
 it('keeps inheriting an unsampled parent when no job sampling rule matches', function () {
@@ -396,5 +394,4 @@ it('applies a job sampling rule to a job dispatched without a traceparent', func
     $span = $flare->job()->recordStartFromJob('App\\Jobs\\Send', 'App\\Jobs\\Send');
 
     expect($span)->not()->toBeNull();
-    expect($span->attributes)->not()->toHaveKey('flare.dispatch.trace_id');
 });


### PR DESCRIPTION
## The problem

A customer reported that one hourly scheduled command fans out into 1,800 jobs, and with a 10% rate they either trace the whole hour or none of it. They tried `DynamicSampler` with job and queue rules and saw no effect.

They were right about the symptom. The cause is a bug.

`JobRecorder::recordStart()` called `lifecycle->startSubtask()` before registering the queue entry point. `startSubtask()` triggers the sampling decision, so the sampler was still looking at the CLI entry point of the queue worker. `JobSamplingRule` and the Laravel queue rules only apply to `EntryPointType::Queue`, so they never matched, no deferred flag was set, and `reevaluateSampling()` returned immediately because the sampler was not deferred.

Net effect: for every queued job the decision was `parentSampled ?? base_rate`. `forJob`, `forQueueName` and `forQueueConnection` did nothing inside a worker.

## The fix

Register the queue entry point before starting the subtask. The sampler now sees a resolved queue entry point and the rules match. `DynamicSampler` already returns a matching rule's rate before falling back to the inherited decision, so a rule now correctly wins over the parent.

Second part: when a rule samples a job whose parent was not sampled, start a new trace. The dispatcher still stamps every job with a traceparent even when it decided not to sample, so all 1,800 siblings carry the same trace id pointing at a parent span that was never sent. Continuing that trace would merge every rule-sampled job into one trace with no root span. The originating trace id is kept on the job span as `flare.dispatch.trace_id` so the link is not lost.

## Behaviour

| Dispatcher | Rule | Before | After |
|---|---|---|---|
| not sampled | matches at 1.0 | not traced | traced, own root trace |
| sampled | matches at 0 | traced | not traced |
| sampled | matches at 1.0 | traced, child of parent | unchanged |
| any | no rule matches | inherits | unchanged |

Nobody without job or queue rules sees a change. Anyone with those rules gets their config applied for the first time, so traced volume shifts. That deserves a clear changelog note rather than a quiet patch release.

One consequence worth naming: a rule wins in both directions, so `forQueueName(..., 0.1)` also thins child jobs out of a command trace that was sampled.

## Tests

Five new cases in `JobRecorderTest` covering the matrix above. Suite goes from 516 to 521 passing. PHPStan clean.

The matching Laravel side rules (`forQueueName`, `forQueueConnection`) are covered in a laravel-flare branch that needs this released first.