### PR TITLE
Send the pretty package version as the telemetry SDK version

### DIFF
--- a/src/Support/Telemetry.php
+++ b/src/Support/Telemetry.php
@@ -19,6 +19,6 @@ class Telemetry
             return 'unknown';
         }
 
-        return InstalledVersions::getVersion(static::NAME) ?? 'unknown';
+        return InstalledVersions::getPrettyVersion(static::NAME) ?? 'unknown';
     }
 }

--- a/src/Support/Tester.php
+++ b/src/Support/Tester.php
@@ -2,7 +2,6 @@
 
 namespace Spatie\FlareClient\Support;
 
-use Composer\InstalledVersions;
 use Exception;
 use Monolog\Level;
 use Spatie\FlareClient\Api;
@@ -368,7 +367,7 @@ abstract class Tester
         return [
             ['Platform', PHP_OS],
             ['PHP', phpversion()],
-            ['spatie/flare-client-php', InstalledVersions::getVersion('spatie/flare-client-php') ?? 'Unknown'],
+            ['spatie/flare-client-php', Telemetry::getVersion()],
             ['Curl', curl_version()['version'] ?? 'Unknown'],
             ['SSL', curl_version()['ssl_version'] ?? 'Unknown'],
         ];


### PR DESCRIPTION
`Composer\InstalledVersions::getVersion()` returns the normalized version, so every report and trace carried `telemetry.sdk.version` values like `3.5.0.0` instead of `3.5.0`. That extra segment shows up in Flare and makes version comparisons on the server side awkward.

Switching to `getPrettyVersion()` sends `3.5.0`. `spatie/laravel-flare` extends this class, so its SDK version becomes pretty as well.

The `flare:test` environment table used the same normalized call, so it now goes through `Telemetry::getVersion()` too.