### PR TITLE
Record failed cache writes, forgets and store failovers

### DIFF
--- a/src/Recorders/CacheRecorder/CacheRecorder.php
+++ b/src/Recorders/CacheRecorder/CacheRecorder.php
@@ -9,6 +9,7 @@ use Spatie\FlareClient\Enums\SpanEventType;
 use Spatie\FlareClient\Recorders\SpanEventsRecorder;
 use Spatie\FlareClient\Spans\SpanEvent;
 use Spatie\FlareClient\Support\PatternMatcher;
+use Throwable;
 
 class CacheRecorder extends SpanEventsRecorder
 {
@@ -57,6 +58,36 @@ class CacheRecorder extends SpanEventsRecorder
         return $this->record($key, $store, CacheOperation::Forget, CacheResult::Success);
     }
 
+    public function recordKeyWriteFailed(string $key, ?string $store): ?SpanEvent
+    {
+        return $this->record($key, $store, CacheOperation::Set, CacheResult::Failure);
+    }
+
+    public function recordKeyForgetFailed(string $key, ?string $store): ?SpanEvent
+    {
+        return $this->record($key, $store, CacheOperation::Forget, CacheResult::Failure);
+    }
+
+    /**
+     * A store falling over is an operational event without a key or an operation, so it is never
+     * filtered by the ignored keys or the configured operations.
+     */
+    public function recordFailedOver(?string $store, ?Throwable $exception = null): ?SpanEvent
+    {
+        return $this->spanEvent(
+            $store === null ? 'Cache failed over' : "Cache failed over - {$store}",
+            attributes: [
+                'flare.span_event_type' => SpanEventType::Cache,
+                'cache.result' => CacheResult::Failure,
+                'cache.store' => $store,
+                ...$exception === null ? [] : [
+                    'exception.message' => $exception->getMessage(),
+                    'exception.type' => $exception::class,
+                ],
+            ]
+        );
+    }
+
     public function record(
         string $key,
         ?string $store,
@@ -77,6 +108,8 @@ class CacheRecorder extends SpanEventsRecorder
             [CacheOperation::Get, CacheResult::Miss] => 'miss',
             [CacheOperation::Set, CacheResult::Success] => 'key written',
             [CacheOperation::Forget, CacheResult::Success] => 'key forgotten',
+            [CacheOperation::Set, CacheResult::Failure] => 'key write failed',
+            [CacheOperation::Forget, CacheResult::Failure] => 'key forget failed',
             default => '',
         };
 

--- a/tests/Recorders/CacheRecorder/CacheRecorderTest.php
+++ b/tests/Recorders/CacheRecorder/CacheRecorderTest.php
@@ -133,3 +133,107 @@ it('can ignore cache keys', function () {
 
     expect($recorder->getSpanEvents())->toBe([$recorded]);
 });
+
+it('can record failed cache writes and forgets', function () {
+    $flare = setupFlare();
+
+    $recorder = new CacheRecorder(
+        tracer: $flare->tracer,
+        backTracer: $flare->backTracer,
+        config: [
+            'with_traces' => true,
+            'with_errors' => true,
+            'max_items_with_errors' => 10,
+            'operations' => [CacheOperation::Get, CacheOperation::Set, CacheOperation::Forget],
+        ]
+    );
+
+    $recorder->boot();
+
+    $recorder->recordKeyWriteFailed('key', 'store');
+    $recorder->recordKeyForgetFailed('key', 'store');
+
+    $events = $recorder->getSpanEvents();
+
+    expect($events)->toHaveCount(2);
+
+    expect($events[0])
+        ->toBeInstanceOf(SpanEvent::class)
+        ->name->toBe('Cache key write failed - key')
+        ->attributes
+        ->toHaveCount(5)
+        ->toHaveKey('flare.span_event_type', SpanEventType::Cache)
+        ->toHaveKey('cache.key', 'key')
+        ->toHaveKey('cache.store', 'store')
+        ->toHaveKey('cache.operation', CacheOperation::Set)
+        ->toHaveKey('cache.result', CacheResult::Failure);
+
+    expect($events[1])
+        ->toBeInstanceOf(SpanEvent::class)
+        ->name->toBe('Cache key forget failed - key')
+        ->attributes
+        ->toHaveCount(5)
+        ->toHaveKey('flare.span_event_type', SpanEventType::Cache)
+        ->toHaveKey('cache.key', 'key')
+        ->toHaveKey('cache.store', 'store')
+        ->toHaveKey('cache.operation', CacheOperation::Forget)
+        ->toHaveKey('cache.result', CacheResult::Failure);
+});
+
+it('ignores failed cache writes and forgets for ignored keys', function () {
+    $flare = setupFlare();
+
+    $recorder = new CacheRecorder(
+        tracer: $flare->tracer,
+        backTracer: $flare->backTracer,
+        config: [
+            'with_traces' => true,
+            'with_errors' => true,
+            'max_items_with_errors' => 10,
+            'operations' => [CacheOperation::Get, CacheOperation::Set, CacheOperation::Forget],
+            'ignored_keys' => ['/^framework:/'],
+        ]
+    );
+
+    $recorder->boot();
+
+    $recorder->recordKeyWriteFailed('framework:schedule', 'store');
+    $recorder->recordKeyForgetFailed('framework:schedule', 'store');
+
+    expect($recorder->getSpanEvents())->toBeEmpty();
+});
+
+it('records a cache store failing over without filtering it', function () {
+    $flare = setupFlare();
+
+    $recorder = new CacheRecorder(
+        tracer: $flare->tracer,
+        backTracer: $flare->backTracer,
+        config: [
+            'with_traces' => true,
+            'with_errors' => true,
+            'max_items_with_errors' => 10,
+            'operations' => [],
+            'ignored_keys' => ['//'],
+        ]
+    );
+
+    $recorder->boot();
+
+    $recorder->recordFailedOver('redis', new RuntimeException('Connection refused'));
+
+    $events = $recorder->getSpanEvents();
+
+    expect($events)->toHaveCount(1);
+
+    expect($events[0])
+        ->toBeInstanceOf(SpanEvent::class)
+        ->name->toBe('Cache failed over - redis')
+        ->attributes
+        ->toHaveCount(5)
+        ->toHaveKey('flare.span_event_type', SpanEventType::Cache)
+        ->toHaveKey('cache.store', 'redis')
+        ->toHaveKey('cache.result', CacheResult::Failure)
+        ->toHaveKey('exception.message', 'Connection refused')
+        ->toHaveKey('exception.type', RuntimeException::class);
+});


### PR DESCRIPTION
The `CacheRecorder` only recorded successful cache operations. A store that silently refuses writes, or one that falls over to its backup, produced no span events at all.

This adds three recording methods to the base recorder:

- `recordKeyWriteFailed()` records `CacheOperation::Set` with the already existing but unused `CacheResult::Failure`.
- `recordKeyForgetFailed()` does the same for `CacheOperation::Forget`.
- `recordFailedOver()` records a store falling over to its backup.

The name `match()` in `record()` gained the two new operation and result combinations, otherwise the span event name would come out empty.

Failed writes and forgets run through the same ignored key filtering as their successful counterparts. A failover has no key and no operation, so it bypasses both the ignored keys and the configured operations. It carries the store name plus `exception.message` and `exception.type` when an exception is available.

The Laravel side is in spatie/laravel-flare.