### PR TITLE
Record cache flushes and lock flushes

### DIFF
--- a/src/Enums/CacheOperation.php
+++ b/src/Enums/CacheOperation.php
@@ -7,4 +7,5 @@ enum CacheOperation: string
     case Get = 'get';
     case Set = 'set';
     case Forget = 'forget';
+    case Flush = 'flush';
 }

--- a/src/Recorders/CacheRecorder/CacheRecorder.php
+++ b/src/Recorders/CacheRecorder/CacheRecorder.php
@@ -21,7 +21,7 @@ class CacheRecorder extends SpanEventsRecorder
     /** @var array<int, string> */
     protected array $ignoredKeys = [];
 
-    public const DEFAULT_OPERATIONS = [CacheOperation::Get, CacheOperation::Set, CacheOperation::Forget];
+    public const DEFAULT_OPERATIONS = [CacheOperation::Get, CacheOperation::Set, CacheOperation::Forget, CacheOperation::Flush];
 
     public static function type(): string|RecorderType
     {
@@ -68,6 +68,26 @@ class CacheRecorder extends SpanEventsRecorder
         return $this->record($key, $store, CacheOperation::Forget, CacheResult::Failure);
     }
 
+    public function recordFlushed(?string $store): ?SpanEvent
+    {
+        return $this->record('', $store, CacheOperation::Flush, CacheResult::Success);
+    }
+
+    public function recordFlushFailed(?string $store): ?SpanEvent
+    {
+        return $this->record('', $store, CacheOperation::Flush, CacheResult::Failure);
+    }
+
+    public function recordLocksFlushed(?string $store): ?SpanEvent
+    {
+        return $this->record('', $store, CacheOperation::Flush, CacheResult::Success, name: 'locks flushed');
+    }
+
+    public function recordLocksFlushFailed(?string $store): ?SpanEvent
+    {
+        return $this->record('', $store, CacheOperation::Flush, CacheResult::Failure, name: 'locks flush failed');
+    }
+
     /**
      * A store falling over is an operational event without a key or an operation, so it is never
      * filtered by the ignored keys or the configured operations.
@@ -94,32 +114,35 @@ class CacheRecorder extends SpanEventsRecorder
         CacheOperation $operation,
         CacheResult $result,
         array $attributes = [],
+        ?string $name = null,
     ): ?SpanEvent {
         if (! in_array($operation, $this->operations)) {
             return null;
         }
 
-        if ($this->shouldIgnoreKey($key)) {
+        if ($key !== '' && $this->shouldIgnoreKey($key)) {
             return null;
         }
 
-        $name = match ([$operation, $result]) {
+        $name ??= match ([$operation, $result]) {
             [CacheOperation::Get, CacheResult::Hit] => 'hit',
             [CacheOperation::Get, CacheResult::Miss] => 'miss',
             [CacheOperation::Set, CacheResult::Success] => 'key written',
             [CacheOperation::Forget, CacheResult::Success] => 'key forgotten',
             [CacheOperation::Set, CacheResult::Failure] => 'key write failed',
             [CacheOperation::Forget, CacheResult::Failure] => 'key forget failed',
+            [CacheOperation::Flush, CacheResult::Success] => 'flushed',
+            [CacheOperation::Flush, CacheResult::Failure] => 'flush failed',
             default => '',
         };
 
         return $this->spanEvent(
-            "Cache {$name} - {$key}",
+            $key === '' ? "Cache {$name}" : "Cache {$name} - {$key}",
             attributes: [
                 'flare.span_event_type' => SpanEventType::Cache,
                 'cache.operation' => $operation,
                 'cache.result' => $result,
-                'cache.key' => $key,
+                ...$key === '' ? [] : ['cache.key' => $key],
                 'cache.store' => $store,
                 ...$attributes,
             ]

--- a/tests/Recorders/CacheRecorder/CacheRecorderTest.php
+++ b/tests/Recorders/CacheRecorder/CacheRecorderTest.php
@@ -237,3 +237,72 @@ it('records a cache store failing over without filtering it', function () {
         ->toHaveKey('exception.message', 'Connection refused')
         ->toHaveKey('exception.type', RuntimeException::class);
 });
+
+it('can record cache flushes without a key', function () {
+    $flare = setupFlare();
+
+    $recorder = new CacheRecorder(
+        tracer: $flare->tracer,
+        backTracer: $flare->backTracer,
+        config: [
+            'with_traces' => true,
+            'with_errors' => true,
+            'max_items_with_errors' => 10,
+            'operations' => [CacheOperation::Flush],
+            'ignored_keys' => ['//'],
+        ]
+    );
+
+    $recorder->boot();
+
+    $recorder->recordFlushed('store');
+    $recorder->recordFlushFailed('store');
+    $recorder->recordLocksFlushed('store');
+    $recorder->recordLocksFlushFailed('store');
+
+    $events = $recorder->getSpanEvents();
+
+    expect($events)->toHaveCount(4);
+
+    expect(array_map(fn (SpanEvent $event) => $event->name, $events))->toBe([
+        'Cache flushed',
+        'Cache flush failed',
+        'Cache locks flushed',
+        'Cache locks flush failed',
+    ]);
+
+    expect($events[0])
+        ->attributes
+        ->toHaveCount(4)
+        ->toHaveKey('flare.span_event_type', SpanEventType::Cache)
+        ->toHaveKey('cache.store', 'store')
+        ->toHaveKey('cache.operation', CacheOperation::Flush)
+        ->toHaveKey('cache.result', CacheResult::Success)
+        ->not()->toHaveKey('cache.key');
+
+    expect($events[1]->attributes)->toHaveKey('cache.result', CacheResult::Failure);
+    expect($events[2]->attributes)->toHaveKey('cache.result', CacheResult::Success);
+    expect($events[3]->attributes)->toHaveKey('cache.result', CacheResult::Failure);
+});
+
+it('does not record cache flushes when the flush operation is not collected', function () {
+    $flare = setupFlare();
+
+    $recorder = new CacheRecorder(
+        tracer: $flare->tracer,
+        backTracer: $flare->backTracer,
+        config: [
+            'with_traces' => true,
+            'with_errors' => true,
+            'max_items_with_errors' => 10,
+            'operations' => [CacheOperation::Get],
+        ]
+    );
+
+    $recorder->boot();
+
+    $recorder->recordFlushed('store');
+    $recorder->recordLocksFlushed('store');
+
+    expect($recorder->getSpanEvents())->toBeEmpty();
+});


### PR DESCRIPTION
Builds on #97, so review that one first.

Flushing a cache wipes everything a request depends on, but the recorder had no way to express it. This adds a `CacheOperation::Flush` case and four recording methods:

- `recordFlushed()` and `recordFlushFailed()`
- `recordLocksFlushed()` and `recordLocksFlushFailed()`

A flush has no key, so `record()` now handles an empty key deliberately. It skips the ignored key filtering (an empty key would otherwise be matched by a loose user regex), it omits the `cache.key` attribute, and it builds the span event name without the trailing key. The lock variants pass an explicit name because the operation and result pair alone cannot tell them apart from a regular flush.

`Flush` is part of `DEFAULT_OPERATIONS`. A flush is rare and high signal, so it does not add noise, and it still respects the configured operations like every other cache event.